### PR TITLE
절대 경로 및 re-export 설정 변경

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,10 @@
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     ],
-    "react-refresh/only-export-components": ["warn", { "allowConstantExport": true }],
+    "react-refresh/only-export-components": [
+      "warn",
+      { "allowConstantExport": true }
+    ],
     "import/extensions": [
       "error",
       "ignorePackages",
@@ -51,7 +54,16 @@
     "import/order": [
       "error",
       {
-        "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"],
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+          "type"
+        ],
         "pathGroups": [
           {
             "pattern": "{react*}",
@@ -59,42 +71,42 @@
           },
 
           {
-            "pattern": "{@pages,@pages/*,@pages/**/*,@components,@components/*,@components/**/*,@stories,@stories/*,@stories/**/*}",
+            "pattern": "{pages,pages/*,pages/**/*,components,components/*,components/**/*,stories,stories/*,stories/**/*}",
             "group": "internal",
             "position": "before"
           },
 
           {
-            "pattern": "{@states,@states/*,@states/**/*}",
+            "pattern": "{states,states/*,states/**/*}",
             "group": "internal",
             "position": "before"
           },
 
           {
-            "pattern": "{@hooks,@hooks/*,@hooks/**/*,@services,@services/*,@services/**/*,@utils,@utils/*,@utils/**/*}",
+            "pattern": "{hooks,hooks/*,hooks/**/*,services,services/*,services/**/*,utils,utils/*,utils/**/*}",
             "group": "internal",
             "position": "before"
           },
 
           {
-            "pattern": "{@types,@types/*,@types/**/*,}",
+            "pattern": "{types,types/*,types/**/*,}",
             "group": "internal",
             "position": "before"
           },
 
           {
-            "pattern": "{@assets,@assets/*,@assets/**/*,}",
+            "pattern": "{assets,assets/*,assets/**/*,}",
             "group": "internal",
             "position": "before"
           },
 
           {
-            "pattern": "{@styles,@styles/*,@styles/**/*,}",
+            "pattern": "{styles,styles/*,styles/**/*,}",
             "group": "internal",
             "position": "before"
           },
           {
-            "pattern": "./*.module.scss",
+            "pattern": "{./*.module,./*.module.scss,*.css,*.scss}",
             "group": "sibling",
             "position": "after"
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,5 @@
 import { Outlet } from 'react-router-dom';
 
-// import styles from './app.module.scss';
-
 const App = () => (
   <>
     <header>header</header>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,0 @@
-export { default as SearchResult } from './SearchResult';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,10 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import 'minireset.css';
 
+import Product from 'pages/Product';
+import ProductList from 'pages/ProductList';
+
 import App from './App';
-import { Product, ProductList } from './pages';
 
 const router = createBrowserRouter([
   {

--- a/src/pages/ProductList/index.tsx
+++ b/src/pages/ProductList/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import SearchResult from '@components/SearchResult';
+import SearchResult from 'components/SearchResult';
 
 import CategoryList from './CategoryList';
 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,0 @@
-export { default as Product } from './Product';
-export { default as ProductList } from './ProductList';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,16 +10,16 @@
     /* Path config */
     "baseUrl": ".",
     "paths": {
-      "@assets/*": ["src/assets/*"],
-      "@components/*": ["src/components/*"],
-      "@hooks/*": ["src/hooks/*"],
-      "@pages/*": ["src/pages/*"],
-      "@services/*": ["src/services/*"],
-      "@states/*": ["src/states/*"],
-      "@stories/*": ["src/stories/*"],
-      "@styles/*": ["src/styles/*"],
-      "@types/*": ["src/types/*"],
-      "@utils/*": ["src/utils/*"]
+      "assets/*": ["src/assets/*"],
+      "components/*": ["src/components/*"],
+      "hooks/*": ["src/hooks/*"],
+      "pages/*": ["src/pages/*"],
+      "services/*": ["src/services/*"],
+      "states/*": ["src/states/*"],
+      "stories/*": ["src/stories/*"],
+      "styles/*": ["src/styles/*"],
+      "types/*": ["src/types/*"],
+      "utils/*": ["src/utils/*"]
     },
 
     /* Bundler mode */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,16 +6,46 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: [
-      { find: '@assets', replacement: path.resolve(__dirname, 'src/assets') },
-      { find: '@components', replacement: path.resolve(__dirname, 'src/components') },
-      { find: '@hooks', replacement: path.resolve(__dirname, 'src/hooks') },
-      { find: '@pages', replacement: path.resolve(__dirname, 'src/pages') },
-      { find: '@services', replacement: path.resolve(__dirname, 'src/services') },
-      { find: '@states', replacement: path.resolve(__dirname, 'src/states') },
-      { find: '@stories', replacement: path.resolve(__dirname, 'src/stories') },
-      { find: '@styles', replacement: path.resolve(__dirname, 'src/styles') },
-      { find: '@types', replacement: path.resolve(__dirname, 'src/types') },
-      { find: '@utils', replacement: path.resolve(__dirname, 'src/utils') },
+      {
+        find: 'assets',
+        replacement: path.resolve(__dirname, 'src/assets'),
+      },
+      {
+        find: 'components',
+        replacement: path.resolve(__dirname, 'src/components'),
+      },
+      {
+        find: 'hooks',
+        replacement: path.resolve(__dirname, 'src/hooks'),
+      },
+      {
+        find: 'pages',
+        replacement: path.resolve(__dirname, 'src/pages'),
+      },
+      {
+        find: 'services',
+        replacement: path.resolve(__dirname, 'src/services'),
+      },
+      {
+        find: 'states',
+        replacement: path.resolve(__dirname, 'src/states'),
+      },
+      {
+        find: 'stories',
+        replacement: path.resolve(__dirname, 'src/stories'),
+      },
+      {
+        find: 'styles',
+        replacement: path.resolve(__dirname, 'src/styles'),
+      },
+      {
+        find: 'types',
+        replacement: path.resolve(__dirname, 'src/types'),
+      },
+      {
+        find: 'utils',
+        replacement: path.resolve(__dirname, 'src/utils'),
+      },
     ],
   },
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #61 

## 📝작업 내용

- 절대 경로 설정 변경
  - 기존: `@types/someType`
  - 변경: `types/someType`
- eslint import order 규칙을 변경한 절대 경로 설정에 맞도록 수정
- module re-export 하지 않도록 변경
