### PR TITLE
Feat/3

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,8 @@
 // 모든 스토리들에 글로벌하게 적용될 포멧 세팅
 import type { Preview } from '@storybook/react';
 
+import 'styles/hardreset.css';
+
 // npx sb init으로 설정된 기본 값
 const preview: Preview = {
   parameters: {

--- a/src/components/Tabs/index.module.scss
+++ b/src/components/Tabs/index.module.scss
@@ -1,0 +1,27 @@
+.wrapper_list {
+  display: flex;
+  width: 100%;
+}
+
+.wrapper_tab {
+  margin-right: 33px;
+  padding: 14px 0;
+  line-height: 22px;
+  font-weight: 400;
+
+  &.on {
+    font-weight: 700;
+    border-bottom: 4px solid #000;
+  }
+}
+
+.txt_name {
+  font-size: 18px;
+}
+
+.txt_description {
+  margin-left: 5px;
+  font-size: 14px;
+  font-weight: 400;
+  color: #999;
+}

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,0 +1,43 @@
+import clsx from 'clsx';
+import { useState } from 'react';
+
+import { Tab } from 'types/tab';
+
+import styles from './index.module.scss';
+
+type TabProps = {
+  initialTabId: Tab['id'];
+  tabs: Tab[];
+};
+
+const Tabs = ({ initialTabId = 0, tabs }: TabProps) => {
+  const [currentTabId, setCurrentTabId] = useState<Tab['id']>(initialTabId);
+
+  return (
+    <>
+      <ul className={styles.wrapper_list}>
+        {tabs.map((tab) => (
+          <li
+            key={tab.id}
+            value={tab.name}
+            className={clsx(styles.wrapper_tab, {
+              [styles.on]: currentTabId === tab.id,
+            })}
+          >
+            <button type="button" onClick={() => setCurrentTabId(tab.id)}>
+              <span className={styles.txt_name}>{tab.name}</span>
+              {tab.description && (
+                <span className={styles.txt_description}>
+                  {tab.description}
+                </span>
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {tabs[currentTabId].content}
+    </>
+  );
+};
+
+export default Tabs;

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Tabs from 'components/Tabs';
+
+const meta: Meta<typeof Tabs> = {
+  component: Tabs,
+  title: 'Tabs',
+  decorators: [
+    (Story) => (
+      <div style={{ width: 1280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+export const BaseTabs: Story = {
+  args: {
+    initialTabId: 0,
+    tabs: [
+      {
+        id: 0,
+        name: '예시 탭',
+        description: '10,000',
+        content: '첫 번째 탭 콘텐츠입니다.',
+      },
+      {
+        id: 1,
+        name: '두 번째 탭',
+        description: '(999)',
+        content: '두 번째 탭 콘텐츠입니다.',
+      },
+      {
+        id: 2,
+        name: '탭 삼',
+        content: '세 번째 탭 콘텐츠입니다.',
+      },
+    ],
+  },
+};

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -1,0 +1,6 @@
+export type Tab = {
+  id: number;
+  name: string;
+  description?: string;
+  content: React.ReactNode;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #3 

## 📝작업 내용

![image](https://github.com/KakaoFunding/front-end/assets/82873315/0de169ef-8d3d-46d7-a660-93a0ada12afd)

- 탭 목록 컴포넌트 구현
- 스토리북 글로벌 스타일 (`hardreset.css`) 적용

```
🚨 다양한 탭 디자인 중 위 사진에서 보이는 디자인만 구현했습니다.
변형된 디자인이 필요하면 그 때 작업하는 게 낫겠다고 생각했습니다.
```
