### PR TITLE
Feat/8

### DIFF
--- a/src/pages/Product/DetailMain.tsx
+++ b/src/pages/Product/DetailMain.tsx
@@ -39,7 +39,7 @@ const DetailMain = () => {
         <section className={styles.brand_desc}>
           <div className={styles.wrapper_brand}>
             <Link
-              to={`../brand/${mockData.brandId}`}
+              to={`/brand/${mockData.brandId}`}
               className={styles.link_brand}
             >
               <img
@@ -48,7 +48,7 @@ const DetailMain = () => {
                 alt={`${mockData.brandName}브랜드 이미지`}
               />
               <span className={styles.txt_name}>{mockData.brandName}</span>
-              <span className={styles.ico}>ss</span>
+              <span className={styles.ico} />
             </Link>
           </div>
         </section>

--- a/src/pages/Product/ProductBuyInfo.module.scss
+++ b/src/pages/Product/ProductBuyInfo.module.scss
@@ -1,0 +1,9 @@
+.area_buy_info {
+  padding-top: 30px;
+  position: fixed;
+  right: 40px;
+  width: 30%;
+  height: 100%;
+  padding-left: 20px;
+  border-left: 1px solid #ededed;
+}

--- a/src/pages/Product/ProductBuyInfo.tsx
+++ b/src/pages/Product/ProductBuyInfo.tsx
@@ -1,5 +1,99 @@
+import { useState } from 'react';
+
+import ProductOption from './ProductOption';
+import ProductQuantity from './ProductQuantity';
+
+import styles from './ProductBuyInfo.module.scss';
+
+// 받아올 데이터
+const mockData = {
+  isOption: true,
+  productTitle: '940 코쿤 [New & Limited]',
+  optionTitle: '색상',
+  options: [
+    {
+      id: 1,
+      name: '940 코쿤 [New & Limited]',
+    },
+    {
+      id: 2,
+      name: '934 코랄린 [New & Limited]',
+    },
+    {
+      id: 3,
+      name: '932 아네모네 [New & Limited]',
+    },
+    {
+      id: 4,
+      name: '918 마이 로즈',
+    },
+    {
+      id: 5,
+      name: '916 플러티 코랄',
+    },
+    {
+      id: 6,
+      name: '920 인 러브',
+    },
+    {
+      id: 7,
+      name: '912 드리미 화이트',
+    },
+    {
+      id: 8,
+      name: '914 내츄럴 잠',
+    },
+    {
+      id: 9,
+      name: '922 패션 핑크',
+    },
+    {
+      id: 10,
+      name: '924 폴 포 미',
+    },
+    {
+      id: 11,
+      name: '928 핑크 딜라이트',
+    },
+    {
+      id: 12,
+      name: '930 스윗 트릿',
+    },
+    {
+      id: 13,
+      name: '936 칠링 핑크 [New]',
+    },
+    {
+      id: 14,
+      name: '938 킵 쿨 [New]',
+    },
+  ],
+};
+
+// 수량 + 가격 계산 컴포넌트
 const ProductBuyInfo = () => {
-  return <section>구매정보</section>;
+  const [quantity, setQuantity] = useState<number>(1);
+
+  return (
+    <section className={styles.area_buy_info}>
+      {mockData.isOption ? (
+        <ProductOption
+          optionTitle={mockData.optionTitle}
+          options={mockData.options}
+          quantity={quantity}
+          setQuantity={setQuantity}
+        />
+      ) : (
+        <ProductQuantity
+          hasOption={false}
+          optionName={mockData.productTitle}
+          quantity={quantity}
+          setQuantity={setQuantity}
+        />
+      )}
+      {/* 계산 컴포넌트 */}
+    </section>
+  );
 };
 
 export default ProductBuyInfo;

--- a/src/pages/Product/ProductOption.module.scss
+++ b/src/pages/Product/ProductOption.module.scss
@@ -1,0 +1,43 @@
+@import 'styles/mixins.module';
+
+.default {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  padding: 12px 14px;
+  border: 1px solid #e1e2e3;
+}
+
+.area_option {
+  width: 350px;
+  max-height: 290px;
+  overflow-y: scroll;
+  border: 1px solid #e1e2e3;
+
+  .notice {
+    font-size: 13px;
+    font-weight: 400;
+    letter-spacing: -1px;
+    background-color: #fafafa;
+    color: #4a90e2;
+  }
+
+  .txt_option {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -1px;
+
+    .ico_toggle {
+      @include ico-pd-detail(-180px, -300px, 14px, 9px);
+    }
+
+    .on {
+      @include ico-pd-detail(-180px, -290px, 14px, 9px);
+    }
+  }
+
+  .wrapper_option {
+    display: none;
+  }
+}

--- a/src/pages/Product/ProductOption.tsx
+++ b/src/pages/Product/ProductOption.tsx
@@ -1,0 +1,91 @@
+import clsx from 'clsx';
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+
+import ProductQuantity from './ProductQuantity';
+
+import styles from './ProductOption.module.scss';
+
+// 나중에 타입정의해서 types 폴더로 갈 예정
+type Option = {
+  id: number;
+  name: string;
+};
+
+type ProductOptionProps = {
+  optionTitle: string;
+  options: Option[];
+  quantity: number;
+  setQuantity: Dispatch<SetStateAction<number>>;
+};
+
+const ProductOption = ({
+  optionTitle,
+  options,
+  quantity,
+  setQuantity,
+}: ProductOptionProps) => {
+  const [isToggled, setIsToggled] = useState<boolean>(false);
+  const [selectedOption, setSelectedOption] = useState<
+    false | { id: number; name: string }
+  >(false);
+
+  useEffect(() => {
+    if (selectedOption) {
+      setIsToggled(true);
+    } else {
+      setIsToggled(false);
+    }
+  }, [selectedOption]);
+
+  const handleToggle = () => {
+    if (!selectedOption) {
+      return;
+    }
+    setIsToggled(!isToggled);
+  };
+
+  const handleOptionChange = (option: { id: number; name: string }) =>
+    setSelectedOption(option);
+
+  const handleOptionClear = () => setSelectedOption(false);
+
+  return (
+    <section className={styles.area_option}>
+      <div className={clsx(styles.default, styles.notice)}>
+        선물 받은 친구가 직접 옵션 변경 가능하니 안심하세요!
+      </div>
+      <div className={clsx(styles.default, styles.txt_option)}>
+        {selectedOption ? selectedOption.name : optionTitle}
+        <button type="button" onClick={handleToggle} aria-label="toggle button">
+          <span
+            className={clsx(styles.ico_toggle, { [styles.on]: isToggled })}
+          />
+        </button>
+      </div>
+      <ul className={clsx({ [styles.wrapper_option]: isToggled })}>
+        {options.map((option) => (
+          <li key={option.id} className={styles.default}>
+            {option.name}
+            <input
+              type="radio"
+              name="option"
+              checked={selectedOption && selectedOption.id === option.id}
+              onChange={() => handleOptionChange(option)}
+            />
+          </li>
+        ))}
+      </ul>
+      {selectedOption && (
+        <ProductQuantity
+          hasOption
+          optionName={selectedOption.name}
+          handleOptionClear={handleOptionClear}
+          quantity={quantity}
+          setQuantity={setQuantity}
+        />
+      )}
+    </section>
+  );
+};
+
+export default ProductOption;

--- a/src/pages/Product/ProductQuantity.module.scss
+++ b/src/pages/Product/ProductQuantity.module.scss
@@ -1,0 +1,46 @@
+@import 'styles/mixins.module';
+
+.area_quantity {
+  width: 350px;
+  border: 1px solid #e1e2e3;
+}
+
+.wrapper_option {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 14px;
+  font-weight: 700;
+
+  .ico_toggle {
+    @include ico-pd-detail(-210px, -260px, 19px, 19px);
+  }
+}
+
+.wrapper_quantity {
+  display: flex;
+  justify-content: space-between;
+  margin: 0 14px 14px;
+  border: 1px solid #e1e2e3;
+  height: 40px;
+
+  // 각 스타일 outline 전역에서 없애기
+  .input_option {
+    text-align: center;
+    border: none;
+    outline: none;
+  }
+
+  .ico_quantity {
+    @include center(row);
+
+    margin: 15px;
+  }
+
+  .ico_minus {
+    @include ico-pd-detail(-220px, -250px, 14px, 2px);
+  }
+
+  .ico_plus {
+    @include ico-pd-detail(-200px, -290px, 14px, 14px);
+  }
+}

--- a/src/pages/Product/ProductQuantity.tsx
+++ b/src/pages/Product/ProductQuantity.tsx
@@ -1,0 +1,95 @@
+import clsx from 'clsx';
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+
+import { isValidQuantity } from 'utils/validation';
+
+import styles from './ProductQuantity.module.scss';
+
+type ProductQuantityProps = {
+  hasOption: boolean;
+  optionName: string;
+  quantity: number;
+  setQuantity: Dispatch<SetStateAction<number>>;
+  handleOptionClear?: () => void;
+};
+
+const ProductQuantity = ({
+  hasOption,
+  optionName,
+  quantity,
+  setQuantity,
+  handleOptionClear,
+}: ProductQuantityProps) => {
+  const [input, setInput] = useState<string>('1');
+
+  useEffect(() => {
+    setInput(quantity.toString());
+  }, [quantity]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    setInput(inputValue);
+  };
+
+  const handleBlur = () => {
+    if (isValidQuantity(input)) {
+      const newQuantity = Number(input);
+      setQuantity(newQuantity);
+      setInput(newQuantity.toString());
+      return;
+    }
+    setInput('1');
+  };
+
+  const handlePlusClick = () => {
+    setQuantity(quantity + 1);
+  };
+  const handleMinusClick = () => {
+    if (quantity === 1) return;
+    setQuantity(quantity - 1);
+  };
+
+  // button > span 스토리북으로 컴포넌트화 하기
+  return (
+    <section className={clsx(!hasOption && styles.area_quantity)}>
+      <div className={styles.wrapper_option}>
+        {optionName}
+        {hasOption && (
+          <button
+            type="button"
+            onClick={handleOptionClear}
+            aria-label="toggle button"
+          >
+            <span className={styles.ico_toggle} />
+          </button>
+        )}
+      </div>
+      <div className={styles.wrapper_quantity}>
+        <button
+          type="button"
+          aria-label="minus button"
+          onClick={handleMinusClick}
+          className={styles.ico_quantity}
+        >
+          <span className={styles.ico_minus} />
+        </button>
+        <input
+          value={input}
+          className={styles.input_option}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+        <button
+          type="button"
+          aria-label="plus button"
+          onClick={handlePlusClick}
+          className={styles.ico_quantity}
+        >
+          <span className={styles.ico_plus} />
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ProductQuantity;

--- a/src/pages/Product/index.module.scss
+++ b/src/pages/Product/index.module.scss
@@ -3,13 +3,6 @@
   height: 100vh;
 
   .area_detail_info {
-    display: flex;
     width: 70%;
-    flex-direction: column;
-  }
-
-  .area_buy_info {
-    width: 30%;
-    // background-color: antiquewhite;
   }
 }

--- a/src/pages/Product/index.tsx
+++ b/src/pages/Product/index.tsx
@@ -7,6 +7,7 @@ import ProductBuyInfo from './ProductBuyInfo';
 
 import styles from './index.module.scss';
 
+// 상품 데이터 fetch 해오기
 const Product = () => {
   return (
     <MainWrapper>
@@ -16,9 +17,7 @@ const Product = () => {
           <DetailContents />
           <DetailBottom />
         </section>
-        <section className={styles.area_buy_info}>
-          <ProductBuyInfo />
-        </section>
+        <ProductBuyInfo />
       </article>
     </MainWrapper>
   );

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,9 @@
+export const isValidQuantity = (inputValue: string): boolean => {
+  const quantity = Number(inputValue);
+
+  if (Number.isNaN(quantity) || quantity < 1) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #8 

## 📝작업 내용

#### 옵션 선택 기능 구현
- 선택된 옵션이 없을 때 토글 닫히지 않음 
![image](https://github.com/KakaoFunding/front-end/assets/79066587/2c0daac4-d2bd-4796-9d6d-3c63c9b1683d)
- 옵션 미선택 시 수량 컴포넌트가 보이지 않음
![image](https://github.com/KakaoFunding/front-end/assets/79066587/0cd37b97-8eca-458f-b747-515aa40947d0)
- 옵션 선택 시 토글이 닫힘
- 선택된 옵션 띄우기 
![image](https://github.com/KakaoFunding/front-end/assets/79066587/cfe2efce-1e4e-476e-b9ea-a1f593f496c1)
- 옵션없는 상품일 경우 바로 수량 선택
![image](https://github.com/KakaoFunding/front-end/assets/79066587/998eaa0c-5582-4048-854c-56ee2d5922f7)

 
## 🙏리뷰 요구사항
- 굉장한 스파게티를 만든 기분입니다... 선택된 옵션 유무에 따라 토글버튼 기능 활성화 여부를 구현한 코드와 인풋에서 입력된 값이 포커스 아웃될 때 입력 값을 검증하는 부분이 너무 지저분하네요 ... ㅠ.ㅠ 버튼+스판 태그로 클릭버튼 만드는 부분을 스토리북으로 컴포넌트화 하고 값을 입력받는 부분도 훅으로 빼서 리팩토링 해야할 것 같은데 기능 구현 마치고 해보겠습니다.
- 그리고 전체적으로 컴포넌트 이름이 적절하지 않은것 같고 디렉터리 구조가 너무 복잡한 것 같아요. 하나의 디렉터리에 컴포넌트가 너무 많아서 그런 것 같은데 이와 관련된 부분도 리팩토링때 한번 수정해보겠습니다.
- 라디오버튼 커스텀을 못했어요 ㅠ.. 별로 중요하지 않은 부분이라고 생각해서 나중에 구현하겠습니다.
- 인풋이 포커싱되면 검정색으로 아웃라인이 잡힙니다. 개인적으로 아웃라인은 부수효과라 생각해서 그냥 없애버렸는데 카카오 홈페이지엔 있네요... 포커싱되면 아웃라인 생기도록 해야할까요 ? 만약 아웃라인을 없애게 된다면 전역스타일 시트에서 없애도 좋을 것 같아요! 참고로 서치바는 아웃라인 잡히지 않습니다...!
![image](https://github.com/KakaoFunding/front-end/assets/79066587/98cee39d-c3a3-42be-9c9e-8247fbd2a0b4)
![image](https://github.com/KakaoFunding/front-end/assets/79066587/ea868f8a-abbd-4542-bde3-ce1c06cd7b6d)


