### PR TITLE
Feat/29

### DIFF
--- a/src/layouts/CategoryResult/SearchContents/BrandSummary/index.module.scss
+++ b/src/layouts/CategoryResult/SearchContents/BrandSummary/index.module.scss
@@ -1,0 +1,45 @@
+@import 'styles/mixins.module';
+
+$height: 33px;
+
+.wrapper_title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 40px 0 20px;
+}
+
+.text_title {
+  display: inline-block;
+  font-size: 24px;
+  color: #000;
+  font-weight: 700;
+  height: $height;
+  line-height: $height;
+}
+
+.list_brand {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border: 1px solid #ededed;
+  padding: 30px 27px 20px;
+  margin-bottom: 30px;
+  text-align: center;
+
+  .img_logo {
+    width: 70px;
+    height: 70px;
+    margin: 0 29px 12px;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+
+  .txt_name {
+    font-size: 14px;
+    color: #666;
+    padding: 0 8px;
+
+    @include text-ellipsis(1);
+  }
+}

--- a/src/layouts/CategoryResult/SearchContents/BrandSummary/index.module.scss
+++ b/src/layouts/CategoryResult/SearchContents/BrandSummary/index.module.scss
@@ -1,21 +1,11 @@
-@import 'styles/mixins.module';
+@import '../index.module';
 
-$height: 33px;
-
-.wrapper_title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 40px 0 20px;
+.wrapper_header {
+  @include wrapper-tab-head;
 }
 
-.text_title {
-  display: inline-block;
-  font-size: 24px;
-  color: #000;
-  font-weight: 700;
-  height: $height;
-  line-height: $height;
+.txt_title {
+  @include txt-tab-label;
 }
 
 .list_brand {
@@ -28,18 +18,12 @@ $height: 33px;
   text-align: center;
 
   .img_logo {
-    width: 70px;
-    height: 70px;
-    margin: 0 29px 12px;
-    object-fit: cover;
+    @include img-brand-logo;
+
     border-radius: 4px;
   }
 
   .txt_name {
-    font-size: 14px;
-    color: #666;
-    padding: 0 8px;
-
-    @include text-ellipsis(1);
+    @include txt-brand-name;
   }
 }

--- a/src/layouts/CategoryResult/SearchContents/BrandSummary/index.tsx
+++ b/src/layouts/CategoryResult/SearchContents/BrandSummary/index.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom';
+
+import Spinner from 'components/ui/Spinner';
+
+import { Brand } from 'types/Brand';
+
+import styles from './index.module.scss';
+
+type BrandSummaryProps = {
+  tabName: string;
+  brands: Brand[];
+  isLoading: boolean;
+};
+
+const BrandSummary = ({ tabName, brands, isLoading }: BrandSummaryProps) => {
+  return (
+    <section>
+      <div className={styles.wrapper_title}>
+        <h3 className={styles.text_title}>{tabName}</h3>
+        <div>전체보기</div>
+      </div>
+      {isLoading && <Spinner />}
+      <ul className={styles.list_brand}>
+        {brands.map((brand) => (
+          <li key={brand.brandId} className={styles.item_brand}>
+            <Link to={`/brand/${brand.brandId}`}>
+              <img
+                src={brand.iconPhoto}
+                alt={brand.name}
+                className={styles.img_logo}
+              />
+              <span className={styles.txt_name}>{brand.name}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default BrandSummary;

--- a/src/layouts/CategoryResult/SearchContents/BrandSummary/index.tsx
+++ b/src/layouts/CategoryResult/SearchContents/BrandSummary/index.tsx
@@ -15,8 +15,8 @@ type BrandSummaryProps = {
 const BrandSummary = ({ tabName, brands, isLoading }: BrandSummaryProps) => {
   return (
     <section>
-      <div className={styles.wrapper_title}>
-        <h3 className={styles.text_title}>{tabName}</h3>
+      <div className={styles.wrapper_header}>
+        <h3 className={styles.txt_title}>{tabName}</h3>
         <div>전체보기</div>
       </div>
       {isLoading && <Spinner />}

--- a/src/layouts/CategoryResult/SearchContents/BrandTab/index.module.scss
+++ b/src/layouts/CategoryResult/SearchContents/BrandTab/index.module.scss
@@ -1,32 +1,15 @@
-@import 'styles/mixins.module';
+@import '../index.module';
 
-$height: 33px;
-
-.wrapper_title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 40px 0 20px;
+.wrapper_header {
+  @include wrapper-tab-head;
 }
 
-.text_title {
-  display: inline-block;
-  font-size: 24px;
-  color: #000;
-  font-weight: 700;
-  height: $height;
-  line-height: $height;
+.txt_title {
+  @include txt-tab-label;
 }
 
-.text_count {
-  display: inline-block;
-  font-size: 18px;
-  color: #333;
-  font-weight: 400;
-  line-height: $height;
-  vertical-align: top;
-  letter-spacing: -1px;
-  margin-left: 8px;
+.txt_count {
+  @include txt-tab-count;
 }
 
 .area_brand_tab {
@@ -44,17 +27,10 @@ $height: 33px;
   text-align: center;
 
   .img_logo {
-    width: 70px;
-    height: 70px;
-    margin: 0 29px 12px;
-    object-fit: cover;
+    @include img-brand-logo;
   }
 
   .txt_name {
-    font-size: 14px;
-    color: #666;
-    padding: 0 8px;
-
-    @include text-ellipsis(1);
+    @include txt-brand-name;
   }
 }

--- a/src/layouts/CategoryResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/CategoryResult/SearchContents/BrandTab/index.tsx
@@ -1,50 +1,36 @@
-import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import Slider from 'react-slick';
 
 import SliderArrowButton from 'components/ui/SliderArrowButton';
 import Spinner from 'components/ui/Spinner';
 
-import { useAxios } from 'hooks/useAxios';
 import { formatNumberWithComma } from 'utils/format';
 
 import { Brand } from 'types/Brand';
-import { Category } from 'types/category';
 
 import styles from './index.module.scss';
 
 type BrandTabProps = {
   tabName: string;
-  categoryId: Category['categoryId'];
+  brands: Brand[];
+  isLoading: boolean;
 };
 
-const BrandTab = ({ tabName, categoryId }: BrandTabProps) => {
-  const { data, isLoading, sendRequest } = useAxios<Brand[]>({
-    method: 'get',
-    url: '/brands',
-    params: {
-      categoryId,
-    },
-  });
-
-  useEffect(() => {
-    sendRequest();
-  }, []);
-
+const BrandTab = ({ tabName, brands, isLoading }: BrandTabProps) => {
   return (
     <section className={styles.area_brand_tab}>
       <div className={styles.wrapper_title}>
         <div>
           <h3 className={styles.text_title}>{tabName}</h3>
           <span className={styles.text_count}>
-            {formatNumberWithComma(data?.length ?? 0)}
+            {formatNumberWithComma(brands.length)}
           </span>
         </div>
         <div>정렬 드롭다운</div>
       </div>
       {isLoading && <Spinner />}
       <Slider
-        arrows={data?.length > 40}
+        arrows={brands.length > 40}
         draggable
         speed={300}
         infinite={false}
@@ -57,7 +43,7 @@ const BrandTab = ({ tabName, categoryId }: BrandTabProps) => {
         nextArrow={<SliderArrowButton arrowType="next" />}
         className={styles.wrapper_slider}
       >
-        {data?.map((brand: Brand) => (
+        {brands.map((brand: Brand) => (
           <li key={brand.brandId} className={styles.item_brand}>
             <Link to={`/brand/${brand.brandId}`}>
               <img

--- a/src/layouts/CategoryResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/CategoryResult/SearchContents/BrandTab/index.tsx
@@ -19,10 +19,10 @@ type BrandTabProps = {
 const BrandTab = ({ tabName, brands, isLoading }: BrandTabProps) => {
   return (
     <section className={styles.area_brand_tab}>
-      <div className={styles.wrapper_title}>
+      <div className={styles.wrapper_header}>
         <div>
-          <h3 className={styles.text_title}>{tabName}</h3>
-          <span className={styles.text_count}>
+          <h3 className={styles.txt_title}>{tabName}</h3>
+          <span className={styles.txt_count}>
             {formatNumberWithComma(brands.length)}
           </span>
         </div>

--- a/src/layouts/CategoryResult/SearchContents/ProductTab/index.module.scss
+++ b/src/layouts/CategoryResult/SearchContents/ProductTab/index.module.scss
@@ -1,28 +1,13 @@
-$height: 33px;
+@import '../index.module';
 
-.wrapper_title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 40px 0 20px;
+.wrapper_header {
+  @include wrapper-tab-head;
 }
 
-.text_title {
-  display: inline-block;
-  font-size: 24px;
-  color: #000;
-  font-weight: 700;
-  height: $height;
-  line-height: $height;
+.txt_title {
+  @include txt-tab-label;
 }
 
-.text_count {
-  display: inline-block;
-  font-size: 18px;
-  color: #333;
-  font-weight: 400;
-  line-height: $height;
-  vertical-align: top;
-  letter-spacing: -1px;
-  margin-left: 8px;
+.txt_count {
+  @include txt-tab-count;
 }

--- a/src/layouts/CategoryResult/SearchContents/ProductTab/index.tsx
+++ b/src/layouts/CategoryResult/SearchContents/ProductTab/index.tsx
@@ -55,10 +55,10 @@ const ProductTab = ({ categoryId, tabName }: ProductTabProps) => {
   return (
     <>
       {/* 탭 이름(제목) + 아이템 개수(필터링에 따라 달라질 수 있음) + 정렬 드롭다운 */}
-      <div className={styles.wrapper_title}>
+      <div className={styles.wrapper_header}>
         <div>
-          <h3 className={styles.text_title}>{tabName}</h3>
-          <span className={styles.text_count}>
+          <h3 className={styles.txt_title}>{tabName}</h3>
+          <span className={styles.txt_count}>
             {formatNumberWithComma(count)}
           </span>
         </div>

--- a/src/layouts/CategoryResult/SearchContents/index.module.scss
+++ b/src/layouts/CategoryResult/SearchContents/index.module.scss
@@ -1,0 +1,45 @@
+@import 'styles/mixins.module';
+
+$height: 33px;
+
+@mixin wrapper-tab-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 40px 0 20px;
+}
+
+@mixin txt-tab-label {
+  display: inline-block;
+  font-size: 24px;
+  color: #000;
+  font-weight: 700;
+  height: $height;
+  line-height: $height;
+}
+
+@mixin txt-tab-count {
+  display: inline-block;
+  font-size: 18px;
+  color: #333;
+  font-weight: 400;
+  line-height: $height;
+  vertical-align: top;
+  letter-spacing: -1px;
+  margin-left: 8px;
+}
+
+@mixin img-brand-logo {
+  width: 70px;
+  height: 70px;
+  object-fit: cover;
+  margin: 0 29px 12px;
+}
+
+@mixin txt-brand-name {
+  font-size: 14px;
+  color: #666;
+  padding: 0 8px;
+
+  @include text-ellipsis(1);
+}

--- a/src/layouts/CategoryResult/SearchContents/index.tsx
+++ b/src/layouts/CategoryResult/SearchContents/index.tsx
@@ -1,5 +1,10 @@
+import { useEffect } from 'react';
+
 import Tabs from 'components/ui/Tabs';
 
+import { useAxios } from 'hooks/useAxios';
+
+import { Brand } from 'types/Brand';
 import { Category } from 'types/category';
 import { Tab } from 'types/tab';
 
@@ -11,6 +16,22 @@ type SearchResultProps = {
 };
 
 const SearchContents = ({ categoryId }: SearchResultProps) => {
+  const {
+    data: brands,
+    isLoading: isBrandsFetching,
+    sendRequest: fetchBrands,
+  } = useAxios<Brand[]>({
+    method: 'get',
+    url: '/brands',
+    params: {
+      categoryId,
+    },
+  });
+
+  useEffect(() => {
+    fetchBrands();
+  }, [categoryId]);
+
   const tabs: Tab[] = [
     { id: 0, name: '전체', content: '전체~' },
     {
@@ -21,7 +42,14 @@ const SearchContents = ({ categoryId }: SearchResultProps) => {
     {
       id: 2,
       name: '브랜드',
-      content: <BrandTab tabName="브랜드" categoryId={categoryId} />,
+      description: brands?.length.toString(),
+      content: (
+        <BrandTab
+          tabName="브랜드"
+          brands={brands ?? []}
+          isLoading={isBrandsFetching}
+        />
+      ),
     },
   ];
 

--- a/src/layouts/CategoryResult/SearchContents/index.tsx
+++ b/src/layouts/CategoryResult/SearchContents/index.tsx
@@ -8,6 +8,7 @@ import { Brand } from 'types/Brand';
 import { Category } from 'types/category';
 import { Tab } from 'types/tab';
 
+import BrandSummary from './BrandSummary';
 import BrandTab from './BrandTab';
 import ProductTab from './ProductTab';
 
@@ -33,7 +34,20 @@ const SearchContents = ({ categoryId }: SearchResultProps) => {
   }, [categoryId]);
 
   const tabs: Tab[] = [
-    { id: 0, name: '전체', content: '전체~' },
+    {
+      id: 0,
+      name: '전체',
+      content: (
+        <>
+          <BrandSummary
+            tabName="브랜드"
+            brands={brands?.slice(0, 9) ?? []}
+            isLoading={isBrandsFetching}
+          />
+          <ProductTab tabName="상품" categoryId={categoryId} />
+        </>
+      ),
+    },
     {
       id: 1,
       name: '상품',


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #29 

## 📝작업 내용

![image](https://github.com/KakaoFunding/front-end/assets/82873315/f91be027-4317-495c-a4fa-5b1682ae3ce0)
- 전체 탭에서 일부 브랜드 목록을 보여주는 컴포넌트 구현

## 🙏리뷰 요구사항

- `전체보기` 클릭 시 `브랜드` 탭으로 넘어가야 하는데, 이걸 구현하려면 `Tabs` 컴포넌트를 좀 수정해야 합니다. 그래서 `Tabs` 컴포넌트 리팩터링을 바로 작업하려고 하구요. 작업 완료되면 `전체보기`도 구현하겠습니다!
- 브랜드 탭 PR 코드리뷰가 완료되지 않아서 브랜드 탭 구현사항을 머지하지 못했습니다. PR을 계속 기다릴 순 없어서... 브랜드 탭 구현하던 브랜치(`feat/15`)에서 분기하여 본 브랜치를 만들었습니다. 당장은 코드 리뷰를 편하게 하시라고 `dev`로 머지하지 않고 `feat/15`로 머지하고 있는데요. `feat/15`가 `dev`에 병합되면, 그 때 병합할 브랜치를 `dev`로 변경하도록 하겠습니다.
 
**만약 `feat/15` PR을 확인하지 않으셨다면, 먼저 해당 PR부터 확인해주시면 감사하겠습니다.**