### PR TITLE
[fix]: 잘못된 선물함 컴포넌트명 수정 및 import 오류 해결 (#145)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import App from 'pages/App';
 import Auth from 'pages/Auth';
 import CategoryResult from 'pages/CategoryResult';
 import Funding from 'pages/Funding';
-import Giftbox from 'pages/Giftbox';
+import GiftBox from 'pages/GiftBox';
 import MyPage from 'pages/MyPage';
 import Product from 'pages/Product';
 import Search from 'pages/Search';
@@ -53,7 +53,7 @@ const router = createBrowserRouter([
           },
           {
             path: 'giftbox',
-            element: <Giftbox />,
+            element: <GiftBox />,
           },
         ],
       },

--- a/src/pages/GiftBox/index.tsx
+++ b/src/pages/GiftBox/index.tsx
@@ -1,5 +1,5 @@
-const Giftbox = () => {
+const GiftBox = () => {
   return <>선물함</>;
 };
 
-export default Giftbox;
+export default GiftBox;

--- a/src/pages/Giftbox/index.tsx
+++ b/src/pages/Giftbox/index.tsx
@@ -1,5 +1,5 @@
-const Giftbox = () => {
+const GiftBox = () => {
   return <>선물함</>;
 };
 
-export default Giftbox;
+export default GiftBox;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #145 

## 📝작업 내용

- 선물함 페이지 컴포넌트명 수정: `Giftbox` -> `GiftBox`
- main.tsx 내 선물함 컴포넌트 import 오류 해결

## 🙏리뷰 요구사항

hotfix되어야 할 것 같아 바로 머지하겠습니다.