### PR TITLE
[fix]: 브랜드 카드 컴포넌트 링크 라우트 수정 (#155)

### DIFF
--- a/src/layouts/SearchResult/SearchContents/BrandCard/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandCard/index.tsx
@@ -18,7 +18,7 @@ const BrandCard = ({
   size,
 }: BrandCardProps) => {
   return (
-    <Link to={`brand/${brandId}`}>
+    <Link to={`/brand/${brandId}`}>
       <span className={clsx(styles.wrapper_logo, styles[size])}>
         <img src={iconPhoto} alt={name} />
       </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #155 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 브랜드 카드 클릭 시 `/brand/{brandID}`로 라우팅되도록 수정

## 🙏리뷰 요구사항