### PR TITLE
[feat]: 펀딩 페이지 레이아웃 구현(#117)

### DIFF
--- a/src/pages/Funding/index.module.scss
+++ b/src/pages/Funding/index.module.scss
@@ -1,0 +1,9 @@
+@import 'styles/mixins.module';
+
+.title {
+  @include font(28px, 800);
+
+  margin: 40px 0 30px;
+  line-height: 38px;
+  white-space: pre-line;
+}

--- a/src/pages/Funding/index.tsx
+++ b/src/pages/Funding/index.tsx
@@ -1,5 +1,19 @@
+import styles from './index.module.scss';
+
+const mockdata = {
+  userName: '보경',
+};
 const Funding = () => {
-  return <>펀딩</>;
+  return (
+    <>
+      <div className={styles.title}>
+        {`${mockdata.userName}님의 \n펀딩아이템`}
+      </div>
+
+      <div>펀딩영역</div>
+      <div>펀딩 아이템 추천 영역</div>
+    </>
+  );
 };
 
 export default Funding;

--- a/src/pages/MyPage/index.module.scss
+++ b/src/pages/MyPage/index.module.scss
@@ -13,4 +13,5 @@
 
 .area_main {
   flex-grow: 1;
+  padding-left: 32px;
 }

--- a/src/styles/_mixins.module.scss
+++ b/src/styles/_mixins.module.scss
@@ -10,6 +10,11 @@
   height: 100%;
 }
 
+@mixin font($size, $weight) {
+  font-size: $size;
+  font-weight: $weight;
+}
+
 @mixin size($width, $height, $margin, $padding) {
   width: $width;
   height: $height;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #117

## 📝작업 내용
![image](https://github.com/KakaoFunding/front-end/assets/79066587/2dadbfc7-3c08-4611-bdd8-5746a44dbb2b)

- 펀딩 페이지 레이아웃 구현