### PR TITLE
Feat/137

### DIFF
--- a/src/layouts/SearchResult/SearchContents/BrandTab/BrandMoreSlot/index.module.scss
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/BrandMoreSlot/index.module.scss
@@ -1,0 +1,26 @@
+@import 'styles/mixins.module';
+@import 'styles/variable.module';
+
+.wrapper_thumb {
+  @include center(column);
+
+  $round: 8px;
+
+  &.small {
+    @include wrapper-prod-img($prod-item-small, $round);
+  }
+
+  &.medium {
+    @include wrapper-prod-img($prod-item-medium, $round);
+  }
+}
+
+.ico_more {
+  @include ico-gift3(0, -260px, 40px, 40px);
+}
+
+.txt_more {
+  margin-top: 13px;
+  font-size: 13px;
+  color: #666;
+}

--- a/src/layouts/SearchResult/SearchContents/BrandTab/BrandMoreSlot/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/BrandMoreSlot/index.tsx
@@ -1,0 +1,23 @@
+import clsx from 'clsx';
+import { Link } from 'react-router-dom';
+
+import styles from './index.module.scss';
+
+type BrandMoreSlotProps = {
+  brandId: number;
+  size: 'small' | 'medium';
+};
+
+const BrandMoreSlot = ({ brandId, size }: BrandMoreSlotProps) => {
+  return (
+    <Link
+      to={`/brand/${brandId}`}
+      className={clsx(styles.wrapper_thumb, styles[size])}
+    >
+      <span className={styles.ico_more} />
+      <span className={styles.txt_more}>브랜드 더보기</span>
+    </Link>
+  );
+};
+
+export default BrandMoreSlot;

--- a/src/layouts/SearchResult/SearchContents/BrandTab/ProductCarousel/index.module.scss
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/ProductCarousel/index.module.scss
@@ -1,0 +1,3 @@
+.wrapper_slider {
+  margin-top: 30px;
+}

--- a/src/layouts/SearchResult/SearchContents/BrandTab/ProductCarousel/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/ProductCarousel/index.tsx
@@ -1,0 +1,57 @@
+import Slider from 'react-slick';
+
+import ColumnProductItem from 'components/feature/ProductItem/ColumnProductItem';
+import SliderArrowButton from 'components/ui/SliderArrowButton';
+
+import { ProductItem } from 'types/productItem';
+
+import BrandMoreSlot from '../BrandMoreSlot';
+
+import styles from './index.module.scss';
+
+type ProductCarouselProps = {
+  brandId: number;
+  products: ProductItem[];
+};
+
+const ProductCarousel = ({ brandId, products }: ProductCarouselProps) => {
+  const SLOTS_PER_SLIDE = 4;
+  const MAX_SLOTS = 9;
+
+  return (
+    <Slider
+      arrows={products.length > SLOTS_PER_SLIDE}
+      slidesToShow={SLOTS_PER_SLIDE}
+      slidesToScroll={SLOTS_PER_SLIDE}
+      slide="ul"
+      infinite={false}
+      prevArrow={<SliderArrowButton arrowType="prev" />}
+      nextArrow={<SliderArrowButton arrowType="next" />}
+      className={styles.wrapper_slider}
+    >
+      {
+        // 브랜드 별 상품 목록 생성
+        products.map((product) => (
+          <li key={product.id}>
+            <ColumnProductItem size="medium" product={product} />
+          </li>
+        ))
+      }
+      {
+        // 한 슬라이드를 다 채우지 못하면, 그만큼 빈 슬롯 생성
+        products.length < SLOTS_PER_SLIDE &&
+          Array.from({ length: SLOTS_PER_SLIDE - products.length }).map(
+            (_, i) => <li key={`empty_slot_${i + 1}`} aria-hidden />,
+          )
+      }
+      {
+        // 상품이 더 있으면, 브랜드 더보기 슬롯 생성
+        products.length === MAX_SLOTS && (
+          <BrandMoreSlot size="medium" brandId={brandId} />
+        )
+      }
+    </Slider>
+  );
+};
+
+export default ProductCarousel;

--- a/src/layouts/SearchResult/SearchContents/BrandTab/ProductCarousel/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/ProductCarousel/index.tsx
@@ -21,6 +21,7 @@ const ProductCarousel = ({ brandId, products }: ProductCarouselProps) => {
   return (
     <Slider
       arrows={products.length > SLOTS_PER_SLIDE}
+      draggable={false}
       slidesToShow={SLOTS_PER_SLIDE}
       slidesToScroll={SLOTS_PER_SLIDE}
       slide="ul"

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
@@ -1,0 +1,4 @@
+.item_card {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
@@ -1,4 +1,4 @@
-.item_card {
+.area_card {
   display: flex;
   flex-direction: column;
   padding: 30px 0 100px;

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
@@ -3,7 +3,3 @@
   flex-direction: column;
   padding: 30px 0 100px;
 }
-
-.wrapper_slider {
-  margin-top: 30px;
-}

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.module.scss
@@ -1,4 +1,9 @@
 .item_card {
   display: flex;
   flex-direction: column;
+  padding: 30px 0 100px;
+}
+
+.wrapper_slider {
+  margin-top: 30px;
 }

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
+import Slider from 'react-slick';
 
+import ColumnProductItem from 'components/feature/ProductItem/ColumnProductItem';
 import ResultTabTitle from 'components/ui/ResultTabTitle';
+import SliderArrowButton from 'components/ui/SliderArrowButton';
 import Spinner from 'components/ui/Spinner';
 
 import { useAxios } from 'hooks/useAxios';
@@ -70,6 +73,29 @@ const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
               category=""
               size="large"
             />
+            <Slider
+              arrows={products.length > 4}
+              slidesToShow={4}
+              slidesToScroll={4}
+              slide="ul"
+              infinite={false}
+              prevArrow={<SliderArrowButton arrowType="prev" />}
+              nextArrow={<SliderArrowButton arrowType="next" />}
+              className={styles.wrapper_slider}
+            >
+              {products.map((product) => (
+                <li key={product.id}>
+                  <ColumnProductItem size="medium" product={product} />
+                </li>
+              ))}
+              {products.length < 4 &&
+                Array.from({ length: 4 - products.length }).map((_, i) => (
+                  <li key={`empty_slot_${i + 1}`} aria-hidden />
+                ))}
+              {products.length === 9 && (
+                <li key={brand.brandId}>브랜드 더보기</li>
+              )}
+            </Slider>
           </li>
         ))}
         {isLoading && <Spinner />}

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
@@ -68,52 +68,50 @@ const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
         {/* 정렬 */}
       </ResultTabTitle>
 
-      <ul>
-        {items.map(({ brand, products }) => (
-          <li key={brand.brandId} className={styles.item_card}>
-            <BrandCard
-              brandId={brand.brandId}
-              name={brand.name}
-              iconPhoto={brand.iconPhoto}
-              category=""
-              size="large"
-            />
-            <Slider
-              arrows={products.length > SLOTS_PER_SLIDE}
-              slidesToShow={SLOTS_PER_SLIDE}
-              slidesToScroll={SLOTS_PER_SLIDE}
-              slide="ul"
-              infinite={false}
-              prevArrow={<SliderArrowButton arrowType="prev" />}
-              nextArrow={<SliderArrowButton arrowType="next" />}
-              className={styles.wrapper_slider}
-            >
-              {
-                // 브랜드 별 상품 목록 생성
-                products.map((product) => (
-                  <li key={product.id}>
-                    <ColumnProductItem size="medium" product={product} />
-                  </li>
-                ))
-              }
-              {
-                // 한 슬라이드를 다 채우지 못하면, 그만큼 빈 슬롯 생성
-                products.length < SLOTS_PER_SLIDE &&
-                  Array.from({ length: SLOTS_PER_SLIDE - products.length }).map(
-                    (_, i) => <li key={`empty_slot_${i + 1}`} aria-hidden />,
-                  )
-              }
-              {
-                // 상품이 더 있으면, 브랜드 더보기 슬롯 생성
-                products.length === MAX_SLOTS && (
-                  <BrandMoreSlot size="medium" brandId={brand.brandId} />
+      {items.map(({ brand, products }) => (
+        <article key={brand.brandId} className={styles.area_card}>
+          <BrandCard
+            brandId={brand.brandId}
+            name={brand.name}
+            iconPhoto={brand.iconPhoto}
+            category=""
+            size="large"
+          />
+          <Slider
+            arrows={products.length > SLOTS_PER_SLIDE}
+            slidesToShow={SLOTS_PER_SLIDE}
+            slidesToScroll={SLOTS_PER_SLIDE}
+            slide="ul"
+            infinite={false}
+            prevArrow={<SliderArrowButton arrowType="prev" />}
+            nextArrow={<SliderArrowButton arrowType="next" />}
+            className={styles.wrapper_slider}
+          >
+            {
+              // 브랜드 별 상품 목록 생성
+              products.map((product) => (
+                <li key={product.id}>
+                  <ColumnProductItem size="medium" product={product} />
+                </li>
+              ))
+            }
+            {
+              // 한 슬라이드를 다 채우지 못하면, 그만큼 빈 슬롯 생성
+              products.length < SLOTS_PER_SLIDE &&
+                Array.from({ length: SLOTS_PER_SLIDE - products.length }).map(
+                  (_, i) => <li key={`empty_slot_${i + 1}`} aria-hidden />,
                 )
-              }
-            </Slider>
-          </li>
-        ))}
-        {isLoading && <Spinner />}
-      </ul>
+            }
+            {
+              // 상품이 더 있으면, 브랜드 더보기 슬롯 생성
+              products.length === MAX_SLOTS && (
+                <BrandMoreSlot size="medium" brandId={brand.brandId} />
+              )
+            }
+          </Slider>
+        </article>
+      ))}
+      {isLoading && <Spinner />}
       <div ref={observingTarget} />
     </section>
   );

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+import ResultTabTitle from 'components/ui/ResultTabTitle';
+import Spinner from 'components/ui/Spinner';
+
+import { useAxios } from 'hooks/useAxios';
+import { useInfinityScroll } from 'hooks/useInfinityScroll';
+
+import { Brand } from 'types/Brand';
+import { PaginationResponse } from 'types/PaginationResponse';
+import { ProductItem } from 'types/productItem';
+
+import BrandCard from '../BrandCard';
+
+import styles from './index.module.scss';
+
+type BrandTabProps = {
+  tabName: string;
+  keyword: string;
+};
+
+type Item = {
+  brand: Brand;
+  products: ProductItem[];
+};
+
+const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
+  const [hasNext, setHasNext] = useState<boolean>(true);
+  const [page, setPage] = useState<number>(0);
+  const [items, setItems] = useState<Item[]>([]);
+
+  const { data, isLoading, sendRequest } = useAxios<PaginationResponse<Item>>({
+    method: 'get',
+    url: '/search/products/all',
+    params: {
+      page,
+      size: 20,
+      keyword,
+    },
+  });
+
+  const observingTarget = useInfinityScroll(() => {
+    if (data) setPage(data.pageNumber + 1);
+  }, hasNext);
+
+  useEffect(() => {
+    sendRequest();
+  }, [page]);
+
+  useEffect(() => {
+    if (data) {
+      setItems((prev) => [...prev, ...data.items]);
+      setHasNext(data.hasNext);
+    }
+  }, [data]);
+
+  return (
+    <section>
+      <ResultTabTitle tabName={tabName} count={data?.totalElements}>
+        {/* 정렬 */}
+      </ResultTabTitle>
+
+      <ul>
+        {items.map(({ brand, products }) => (
+          <li key={brand.brandId} className={styles.item_card}>
+            <BrandCard
+              brandId={brand.brandId}
+              name={brand.name}
+              iconPhoto={brand.iconPhoto}
+              category=""
+              size="large"
+            />
+          </li>
+        ))}
+        {isLoading && <Spinner />}
+      </ul>
+      <div ref={observingTarget} />
+    </section>
+  );
+};
+
+export default BrandTab;

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react';
-import Slider from 'react-slick';
 
-import ColumnProductItem from 'components/feature/ProductItem/ColumnProductItem';
 import ResultTabTitle from 'components/ui/ResultTabTitle';
-import SliderArrowButton from 'components/ui/SliderArrowButton';
 import Spinner from 'components/ui/Spinner';
 
 import { useAxios } from 'hooks/useAxios';
@@ -15,7 +12,7 @@ import { ProductItem } from 'types/productItem';
 
 import BrandCard from '../BrandCard';
 
-import BrandMoreSlot from './BrandMoreSlot';
+import ProductCarousel from './ProductCarousel';
 
 import styles from './index.module.scss';
 
@@ -30,9 +27,6 @@ type Item = {
 };
 
 const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
-  const SLOTS_PER_SLIDE = 4;
-  const MAX_SLOTS = 9;
-
   const [hasNext, setHasNext] = useState<boolean>(true);
   const [page, setPage] = useState<number>(0);
   const [items, setItems] = useState<Item[]>([]);
@@ -77,38 +71,7 @@ const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
             category=""
             size="large"
           />
-          <Slider
-            arrows={products.length > SLOTS_PER_SLIDE}
-            slidesToShow={SLOTS_PER_SLIDE}
-            slidesToScroll={SLOTS_PER_SLIDE}
-            slide="ul"
-            infinite={false}
-            prevArrow={<SliderArrowButton arrowType="prev" />}
-            nextArrow={<SliderArrowButton arrowType="next" />}
-            className={styles.wrapper_slider}
-          >
-            {
-              // 브랜드 별 상품 목록 생성
-              products.map((product) => (
-                <li key={product.id}>
-                  <ColumnProductItem size="medium" product={product} />
-                </li>
-              ))
-            }
-            {
-              // 한 슬라이드를 다 채우지 못하면, 그만큼 빈 슬롯 생성
-              products.length < SLOTS_PER_SLIDE &&
-                Array.from({ length: SLOTS_PER_SLIDE - products.length }).map(
-                  (_, i) => <li key={`empty_slot_${i + 1}`} aria-hidden />,
-                )
-            }
-            {
-              // 상품이 더 있으면, 브랜드 더보기 슬롯 생성
-              products.length === MAX_SLOTS && (
-                <BrandMoreSlot size="medium" brandId={brand.brandId} />
-              )
-            }
-          </Slider>
+          <ProductCarousel brandId={brand.brandId} products={products} />
         </article>
       ))}
       {isLoading && <Spinner />}

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
@@ -30,6 +30,9 @@ type Item = {
 };
 
 const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
+  const SLOTS_PER_SLIDE = 4;
+  const MAX_SLOTS = 9;
+
   const [hasNext, setHasNext] = useState<boolean>(true);
   const [page, setPage] = useState<number>(0);
   const [items, setItems] = useState<Item[]>([]);
@@ -76,9 +79,9 @@ const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
               size="large"
             />
             <Slider
-              arrows={products.length > 4}
-              slidesToShow={4}
-              slidesToScroll={4}
+              arrows={products.length > SLOTS_PER_SLIDE}
+              slidesToShow={SLOTS_PER_SLIDE}
+              slidesToScroll={SLOTS_PER_SLIDE}
               slide="ul"
               infinite={false}
               prevArrow={<SliderArrowButton arrowType="prev" />}
@@ -90,11 +93,11 @@ const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
                   <ColumnProductItem size="medium" product={product} />
                 </li>
               ))}
-              {products.length < 4 &&
-                Array.from({ length: 4 - products.length }).map((_, i) => (
-                  <li key={`empty_slot_${i + 1}`} aria-hidden />
-                ))}
-              {products.length === 9 && (
+              {products.length < SLOTS_PER_SLIDE &&
+                Array.from({ length: SLOTS_PER_SLIDE - products.length }).map(
+                  (_, i) => <li key={`empty_slot_${i + 1}`} aria-hidden />,
+                )}
+              {products.length === MAX_SLOTS && (
                 <BrandMoreSlot size="medium" brandId={brand.brandId} />
               )}
             </Slider>

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
@@ -15,6 +15,8 @@ import { ProductItem } from 'types/productItem';
 
 import BrandCard from '../BrandCard';
 
+import BrandMoreSlot from './BrandMoreSlot';
+
 import styles from './index.module.scss';
 
 type BrandTabProps = {
@@ -93,7 +95,7 @@ const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
                   <li key={`empty_slot_${i + 1}`} aria-hidden />
                 ))}
               {products.length === 9 && (
-                <li key={brand.brandId}>브랜드 더보기</li>
+                <BrandMoreSlot size="medium" brandId={brand.brandId} />
               )}
             </Slider>
           </li>

--- a/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/BrandTab/index.tsx
@@ -88,18 +88,27 @@ const BrandTab = ({ tabName, keyword }: BrandTabProps) => {
               nextArrow={<SliderArrowButton arrowType="next" />}
               className={styles.wrapper_slider}
             >
-              {products.map((product) => (
-                <li key={product.id}>
-                  <ColumnProductItem size="medium" product={product} />
-                </li>
-              ))}
-              {products.length < SLOTS_PER_SLIDE &&
-                Array.from({ length: SLOTS_PER_SLIDE - products.length }).map(
-                  (_, i) => <li key={`empty_slot_${i + 1}`} aria-hidden />,
-                )}
-              {products.length === MAX_SLOTS && (
-                <BrandMoreSlot size="medium" brandId={brand.brandId} />
-              )}
+              {
+                // 브랜드 별 상품 목록 생성
+                products.map((product) => (
+                  <li key={product.id}>
+                    <ColumnProductItem size="medium" product={product} />
+                  </li>
+                ))
+              }
+              {
+                // 한 슬라이드를 다 채우지 못하면, 그만큼 빈 슬롯 생성
+                products.length < SLOTS_PER_SLIDE &&
+                  Array.from({ length: SLOTS_PER_SLIDE - products.length }).map(
+                    (_, i) => <li key={`empty_slot_${i + 1}`} aria-hidden />,
+                  )
+              }
+              {
+                // 상품이 더 있으면, 브랜드 더보기 슬롯 생성
+                products.length === MAX_SLOTS && (
+                  <BrandMoreSlot size="medium" brandId={brand.brandId} />
+                )
+              }
             </Slider>
           </li>
         ))}

--- a/src/layouts/SearchResult/SearchContents/index.tsx
+++ b/src/layouts/SearchResult/SearchContents/index.tsx
@@ -5,6 +5,7 @@ import Tabs from 'components/ui/Tabs';
 import { Tab } from 'types/tab';
 
 import BrandSummary from './BrandSummary';
+import BrandTab from './BrandTab';
 import ProductTab from './ProductTab';
 
 const SearchContents = () => {
@@ -27,7 +28,11 @@ const SearchContents = () => {
       name: '상품',
       content: <ProductTab tabName="상품" keyword={keyword} />,
     },
-    { id: 2, name: '브랜드', content: '' },
+    {
+      id: 2,
+      name: '브랜드',
+      content: <BrandTab tabName="브랜드" keyword={keyword} />,
+    },
   ];
 
   return (

--- a/src/mocks/productHandler.ts
+++ b/src/mocks/productHandler.ts
@@ -1,5 +1,6 @@
 import { http, delay, HttpResponse } from 'msw';
 
+import { Brand } from 'types/Brand';
 import { PaginationResponse } from 'types/PaginationResponse';
 import { ProductItem } from 'types/productItem';
 
@@ -64,6 +65,52 @@ export const productHandlers = [
     return HttpResponse.json<PaginationResponse<ProductItem>>({
       hasNext: totalPages > page + 1,
       items: searchResults.slice(page * size, (page + 1) * size),
+      pageNumber: page,
+      pageSize: size,
+      totalPages,
+      totalElements,
+      last: totalPages <= page + 1,
+    });
+  }),
+
+  // 검색을 통한 브랜드 별 상품 목록 조회
+  http.get('/search/products/all', async ({ request }) => {
+    await delay();
+
+    type Item = {
+      brand: Brand;
+      products: ProductItem[];
+    };
+
+    const mockData: Item[] = Array.from({ length: 30 }).map((_, i) => ({
+      brand: {
+        brandId: i,
+        name: `브랜드 ${i}`,
+        iconPhoto:
+          'https://st.kakaocdn.net/product/gift/gift_brand/20200331040444_99ac946c80764be4943227536638f9c2',
+      },
+      products: Array.from({ length: 9 }).map((__, j) => ({
+        id: Number(`${i}${j}`),
+        name: `브랜드 ${i} - 상품 ${j}`,
+        thumbSrc:
+          'https://st.kakaocdn.net/product/gift/product/20200403153820_ceea3bd561f34cc6b276fbc8cbaac690',
+        price: 29800,
+        brandName: `브랜드 ${i}`,
+        wishCount: 12420,
+        isWished: false,
+      })),
+    }));
+
+    const { searchParams } = new URL(request.url);
+
+    const size = Number(searchParams.get('size'));
+    const page = Number(searchParams.get('page'));
+    const totalElements = mockData.length;
+    const totalPages = Math.ceil(totalElements / size);
+
+    return HttpResponse.json<PaginationResponse<Item>>({
+      hasNext: totalPages > page + 1,
+      items: mockData.slice(page * size, (page + 1) * size),
       pageNumber: page,
       pageSize: size,
       totalPages,

--- a/src/mocks/productHandler.ts
+++ b/src/mocks/productHandler.ts
@@ -1,5 +1,7 @@
 import { http, delay, HttpResponse } from 'msw';
 
+import { getRandomNumber } from 'utils/generate';
+
 import { Brand } from 'types/Brand';
 import { PaginationResponse } from 'types/PaginationResponse';
 import { ProductItem } from 'types/productItem';
@@ -89,7 +91,7 @@ export const productHandlers = [
         iconPhoto:
           'https://st.kakaocdn.net/product/gift/gift_brand/20200331040444_99ac946c80764be4943227536638f9c2',
       },
-      products: Array.from({ length: 9 }).map((__, j) => ({
+      products: Array.from({ length: getRandomNumber(1, 9) }).map((__, j) => ({
         id: Number(`${i}${j}`),
         name: `브랜드 ${i} - 상품 ${j}`,
         thumbSrc:

--- a/src/styles/_mixins.module.scss
+++ b/src/styles/_mixins.module.scss
@@ -52,6 +52,7 @@
 @mixin wrapper-prod-img($size, $round) {
   position: relative;
   width: $size;
+  height: $size;
 
   &::before {
     position: absolute;
@@ -67,6 +68,8 @@
   img {
     display: block;
     width: 100%;
+    height: 100%;
+    object-fit: cover;
     border-radius: $round;
   }
 }

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -1,0 +1,3 @@
+export function getRandomNumber(start: number, end: number): number {
+  return Math.floor(start + Math.random() * end);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #137 

## 📝작업 내용

![image](https://github.com/KakaoFunding/front-end/assets/82873315/0fa6e360-6393-4e87-a9bc-0c412046c82e)

- 검색 결과 페이지 - 브랜드 탭 구현
- ProductItem Thumbnail 스타일 리팩토링 (이전과 동일하게 작동하며 css 코드만 변경됨)

## 🙏리뷰 요구사항

### 캐러셀 넓이가 맞지 않는 듯한 모습

![image](https://github.com/KakaoFunding/front-end/assets/82873315/0d4ce3c7-6519-48d6-baa8-0837ed725214)

상품 캐러셀 오른쪽 버튼 보시면 캐러셀 width에 딱 들어맞지 않는 듯한 모습이 보입니다. 하지만 실제로는 width에 딱 들어맞게 있는 게 맞고요... width 또한 1280px로 정상적입니다.
이렇게 보이는 이유는 react-slick 라이브러리가 자동으로 캐러셀 아이템 간에 여백을 넣어주는데, 한 슬라이드 안에서 보이는 가장 오른쪽 아이템에도 여백을 넣기 때문입니다.

원인을 아는데도 해결하지 못한 까닭은, 문제가 되는 스타일 요소를 직접 조작할 수 없어서입니다.
우선 저희가 사용하는 `.module.scss`로는 해당 스타일 요소에 닿을 수가 없습니다. 컴파일하면서 클래스명이 바뀌기 때문이죠.
이전에 보경님께서 상품 상세 조회 페이지에서 상품 썸네일 제작하실 때에도 비슷한 문제가 있어 `.css` + `!important`로 직접 조작하셨었는데요. `.css`에 작성한 스타일은 모든 곳에서 동일하게 적용되기 때문에 이 방법으로는 수정하기가 어려운 상황입니다.

해결방법을 궁색하다 더 미루어선 안될 것 같아 올립니다.
(+ 캐러셀 쓸 때마다 느끼는 거지만 라이브러리가 커스터마이징에 참 불친절한 것 같아 매우 아쉽네요..)

### 검색창 영역

![image](https://github.com/KakaoFunding/front-end/assets/82873315/f4b610c7-6924-4715-9c55-8c60be11cf6a)

검색창 영역이 가장 위에 쌓여 있어야 하는데, 다른 요소 아래에 깔리는 모습입니다.
요거는 이슈 따로 만들어서 해결하도록 하겠습니다.