### PR TITLE
[feat]: 결제 페이지 레이아웃 구현 (#106)

### DIFF
--- a/src/components/ui/MainWrapper/index.tsx
+++ b/src/components/ui/MainWrapper/index.tsx
@@ -1,13 +1,17 @@
+import clsx from 'clsx';
 import { ReactNode } from 'react';
 
 import styles from './index.module.scss';
 
 type MainContentProps = {
   children: ReactNode;
+  className?: string;
 };
 
-const MainWrapper = ({ children }: MainContentProps) => {
-  return <main className={styles.wrapper_main}>{children}</main>;
+const MainWrapper = ({ children, className }: MainContentProps) => {
+  return (
+    <main className={clsx(styles.wrapper_main, className)}>{children}</main>
+  );
 };
 
 export default MainWrapper;

--- a/src/layouts/Bill/FundingDetail/index.tsx
+++ b/src/layouts/Bill/FundingDetail/index.tsx
@@ -1,0 +1,5 @@
+const FundingDetail = () => {
+  return <div>FundingDetail</div>;
+};
+
+export default FundingDetail;

--- a/src/layouts/Bill/GiftDetail/index.tsx
+++ b/src/layouts/Bill/GiftDetail/index.tsx
@@ -1,0 +1,5 @@
+const GiftDetail = () => {
+  return <div>GiftDetail</div>;
+};
+
+export default GiftDetail;

--- a/src/layouts/Bill/MessageCard/index.tsx
+++ b/src/layouts/Bill/MessageCard/index.tsx
@@ -1,0 +1,5 @@
+const MessageCard = () => {
+  return <div>MessageCard</div>;
+};
+
+export default MessageCard;

--- a/src/layouts/Bill/PaymentDetail/index.tsx
+++ b/src/layouts/Bill/PaymentDetail/index.tsx
@@ -1,0 +1,5 @@
+const PaymentDetail = () => {
+  return <div>PaymentDetail</div>;
+};
+
+export default PaymentDetail;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import 'styles/hardreset.css';
 
 import App from 'pages/App';
 import Auth from 'pages/Auth';
+import Bill from 'pages/Bill';
 import CategoryResult from 'pages/CategoryResult';
 import Funding from 'pages/Funding';
 import GiftBox from 'pages/GiftBox';
@@ -79,6 +80,10 @@ const router = createBrowserRouter([
       {
         path: '/search/result',
         element: <SearchResult />,
+      },
+      {
+        path: '/bill/:type',
+        element: <Bill />,
       },
     ],
   },

--- a/src/pages/Bill/index.module.scss
+++ b/src/pages/Bill/index.module.scss
@@ -1,0 +1,20 @@
+@import 'styles/variable.module';
+
+$border-style: 1px solid #ededed;
+
+.wrapper_main {
+  display: flex;
+  position: relative;
+  min-height: calc(100vh - $header-height - $footer-height);
+  border: $border-style;
+  border-width: 0 1px;
+}
+
+.area_field {
+  width: 868px;
+  border-right: $border-style;
+}
+
+.area_payment {
+  width: 410px;
+}

--- a/src/pages/Bill/index.tsx
+++ b/src/pages/Bill/index.tsx
@@ -1,0 +1,32 @@
+import { Navigate, useParams } from 'react-router-dom';
+
+import MainWrapper from 'components/ui/MainWrapper';
+import FundingDetail from 'layouts/Bill/FundingDetail';
+import GiftDetail from 'layouts/Bill/GiftDetail';
+import MessageCard from 'layouts/Bill/MessageCard';
+import PaymentDetail from 'layouts/Bill/PaymentDetail';
+
+import styles from './index.module.scss';
+
+const Bill = () => {
+  const { type } = useParams();
+
+  if (type !== 'gift' && type !== 'funding') {
+    return <Navigate to="/NotFound" />;
+  }
+
+  return (
+    <MainWrapper className={styles.wrapper_main}>
+      <div className={styles.area_field}>
+        <MessageCard />
+        {type === 'gift' && <GiftDetail />}
+        {type === 'funding' && <FundingDetail />}
+      </div>
+      <div className={styles.area_payment}>
+        <PaymentDetail />
+      </div>
+    </MainWrapper>
+  );
+};
+
+export default Bill;

--- a/src/styles/_variable.module.scss
+++ b/src/styles/_variable.module.scss
@@ -7,6 +7,8 @@
 }
 
 $fix-width: 1280px;
+$header-height: 80px;
+$footer-height: 200px;
 
 // 상품 아이템 썸네일 width
 $prod-item-tiny: 85px;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #106 

## 📝작업 내용

![image](https://github.com/KakaoFunding/front-end/assets/82873315/c6e952b3-82af-4593-8de1-f503b6033bad)

- 선물 및 펀딩 결제 페이지 레이아웃 구현

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->

