### PR TITLE
[fix]: 검색창영역 상단 고정 및 위에 쌓기 (#170)

### DIFF
--- a/src/components/feature/SearchBox/index.module.scss
+++ b/src/components/feature/SearchBox/index.module.scss
@@ -2,18 +2,19 @@
 @import 'styles/variable.module';
 
 .area_search {
+  position: sticky;
+  top: $header-height;
+  padding: 10px 0;
+  z-index: 30;
   min-height: 65px;
   background-color: #fff;
 }
 
 .wrapper_input {
-  position: fixed;
-  top: $header-height;
-  left: 0;
-  right: 0;
+  position: relative;
   background-color: #fff;
   width: 640px;
-  margin: 10px auto;
+  margin: auto;
 }
 
 .input {


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #170 

## 📝작업 내용

![image](https://github.com/KakaoFunding/front-end/assets/82873315/487fd304-36d2-4d9a-a41c-0040b3682092)

- 검색창 영역을 상단에 고정
- 검색창 영역이 다른 요소보다 위에 쌓이도록 z-index 설정

## 🙏리뷰 요구사항

