### PR TITLE
Feat/189

### DIFF
--- a/src/components/feature/EmptyItem/index.tsx
+++ b/src/components/feature/EmptyItem/index.tsx
@@ -1,7 +1,7 @@
 import styles from './index.module.scss';
 
 type EmptyItemProps = {
-  type: 'wish' | 'funding';
+  type: 'wish' | 'funding' | 'unavailable_gift';
 };
 
 const choonsikImgUrl = '/src/assets/bg_choonsik.png';
@@ -14,6 +14,10 @@ const EMPTY_ITEM_TEXT = {
   funding: {
     title: `등록된 펀딩 아이템이 없어요`,
     description: `펀딩받고 싶은 선물🎁이 있나요?\n내 취향에 맞는 선물을 등록해보세요~!`,
+  },
+  unavailable_gift: {
+    title: `사용한 선물이 없어요`,
+    description: `받은 선물🎁을 사용하고, 친구에게 고마운 마음을 표현해보세요~!`,
   },
 };
 

--- a/src/layouts/MyPage/GiftBox/GiftItem/index.tsx
+++ b/src/layouts/MyPage/GiftBox/GiftItem/index.tsx
@@ -10,10 +10,11 @@ type GiftItemProps = {
   photo: string;
   senderName: string;
   receivedDate: string;
-  status?: 'finish' | 'cancel';
+  status?: 'unused' | 'finish' | 'cancel';
 };
 
 const BADGE_TEXT = {
+  unused: '미사용',
   finish: '사용완료',
   cancel: '취소환불',
 };

--- a/src/layouts/MyPage/GiftBox/GiftItem/index.tsx
+++ b/src/layouts/MyPage/GiftBox/GiftItem/index.tsx
@@ -3,6 +3,14 @@ import { Link } from 'react-router-dom';
 
 import styles from './index.module.scss';
 
+const BADGE_TEXT = {
+  unused: '미사용',
+  finish: '사용완료',
+  cancel: '취소환불',
+} as const;
+
+type BadgeType = keyof typeof BADGE_TEXT;
+
 type GiftItemProps = {
   productId: number;
   name: string;
@@ -10,13 +18,7 @@ type GiftItemProps = {
   photo: string;
   senderName: string;
   receivedDate: string;
-  status?: 'unused' | 'finish' | 'cancel';
-};
-
-const BADGE_TEXT = {
-  unused: '미사용',
-  finish: '사용완료',
-  cancel: '취소환불',
+  status?: BadgeType;
 };
 
 const GiftItem = ({

--- a/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.module.scss
+++ b/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.module.scss
@@ -1,0 +1,11 @@
+.list_gift {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  row-gap: 30px;
+  max-width: 840px;
+  margin: 30px 0 100px;
+}
+
+.list_use img {
+  opacity: 0.4;
+}

--- a/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
+++ b/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 
+import EmptyItem from 'components/feature/EmptyItem';
 import Spinner from 'components/ui/Spinner';
 
 import { useAxios } from 'hooks/useAxios';
@@ -41,6 +42,10 @@ const UnavailableGiftTab = () => {
       setHasNext(data.hasNext);
     }
   }, [data]);
+
+  if (!hasNext && gifts.length === 0) {
+    return <EmptyItem type="unavailable_gift" />;
+  }
 
   return (
     <>

--- a/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
+++ b/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 
 import { useAxios } from 'hooks/useAxios';
@@ -6,6 +7,8 @@ import { Gift } from 'types/Gift';
 import { PaginationResponse } from 'types/PaginationResponse';
 
 import GiftItem from '../GiftItem';
+
+import styles from './index.module.scss';
 
 const UnavailableGiftTab = () => {
   const [gifts, setGifts] = useState<Gift[]>([]);
@@ -29,7 +32,7 @@ const UnavailableGiftTab = () => {
   }, [data]);
 
   return (
-    <ul>
+    <ul className={clsx(styles.list_gift, styles.list_use)}>
       {gifts.map((gift) => (
         <li key={gift.giftId}>
           <GiftItem

--- a/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
+++ b/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { useAxios } from 'hooks/useAxios';
+
+import { Gift } from 'types/Gift';
+import { PaginationResponse } from 'types/PaginationResponse';
+
+import GiftItem from '../GiftItem';
+
+const UnavailableGiftTab = () => {
+  const [gifts, setGifts] = useState<Gift[]>([]);
+  const { data, sendRequest } = useAxios<PaginationResponse<Gift>>({
+    method: 'get',
+    url: '/gifts/finish', // mock URL
+    params: {
+      page: 0,
+      size: 20,
+    },
+  });
+
+  useEffect(() => {
+    sendRequest();
+  }, []);
+
+  useEffect(() => {
+    if (data) {
+      setGifts((prev) => [...prev, ...data.items]);
+    }
+  }, [data]);
+
+  return (
+    <ul>
+      {gifts.map((gift) => (
+        <li key={gift.giftId}>
+          <GiftItem
+            productId={gift.productId}
+            name={gift.name}
+            brandName={gift.brandName}
+            photo={gift.photo}
+            senderName={gift.senderName}
+            receivedDate={gift.receivedDate}
+            status={gift.status}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default UnavailableGiftTab;

--- a/src/mocks/giftHandler.ts
+++ b/src/mocks/giftHandler.ts
@@ -1,0 +1,45 @@
+import { HttpResponse, http } from 'msw';
+
+import { Gift } from 'types/Gift';
+import { PaginationResponse } from 'types/PaginationResponse';
+
+const unusedGifts: Gift[] = Array.from({ length: 50 }).map((_, i) => ({
+  giftId: i,
+  productId: 1,
+  name: `상품${i}`,
+  brandName: `브랜드${i}`,
+  photo:
+    'https://img1.kakaocdn.net/thumb/C300x300@2x.fwebp.q82/?fname=https%3A%2F%2Fst.kakaocdn.net%2Fproduct%2Fgift%2Fproduct%2F20201230180133_cd30cb29560f4f1f8c7f380eb94e3cf1.png',
+  senderName: '홍길동',
+  receivedDate: '2021.07.01 오전 10:00',
+  expiredDate: '2022.07.01 오전 10:00',
+  status: 'unused',
+}));
+
+const usedGifts: Gift[] = unusedGifts.map((gift) => ({
+  ...gift,
+  status: 'finish',
+}));
+
+export const giftHandlers = [
+  http.get('/gifts/finish', ({ request }) => {
+    const { searchParams } = new URL(request.url);
+
+    const page = Number(searchParams.get('page'));
+    const size = Number(searchParams.get('size'));
+
+    const totalElements = usedGifts.length;
+    const totalPages = Math.ceil(totalElements / size);
+
+    // httpResponse 반환
+    return HttpResponse.json<PaginationResponse<Gift>>({
+      items: usedGifts.slice(page * size, (page + 1) * size),
+      hasNext: totalPages > page + 1,
+      last: totalPages <= page + 1,
+      pageNumber: page,
+      pageSize: size,
+      totalElements,
+      totalPages,
+    });
+  }),
+];

--- a/src/mocks/worker.ts
+++ b/src/mocks/worker.ts
@@ -2,6 +2,7 @@ import { setupWorker } from 'msw/browser';
 
 import { brandHandlers } from './brandHandler';
 import { categoriesHandlers } from './categoriesHandler';
+import { giftHandlers } from './giftHandler';
 import { paymentHandlers } from './paymentHandler';
 import { productHandlers } from './productHandler';
 
@@ -11,6 +12,7 @@ const handlers = [
   ...productHandlers,
   ...brandHandlers,
   ...paymentHandlers,
+  ...giftHandlers,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/pages/MyPage/GiftBox/index.tsx
+++ b/src/pages/MyPage/GiftBox/index.tsx
@@ -1,5 +1,28 @@
+import Tabs from 'components/ui/Tabs';
+import UnavailableGiftTab from 'layouts/MyPage/GiftBox/UnavailableGiftTab';
+
+import { Tab } from 'types/tab';
+
 const GiftBox = () => {
-  return <>선물함</>;
+  const tabs: Tab[] = [
+    {
+      id: 0,
+      name: '사용가능',
+      content: <p>사용가능</p>,
+    },
+    {
+      id: 1,
+      name: '사용완료',
+      content: <UnavailableGiftTab />,
+    },
+  ];
+
+  return (
+    <>
+      <h1>사용가능한 선물이 n개 남아있어요.</h1>
+      <Tabs initialTabId={0} mode="product_list" tabs={tabs} />
+    </>
+  );
 };
 
 export default GiftBox;

--- a/src/types/Gift.ts
+++ b/src/types/Gift.ts
@@ -1,0 +1,11 @@
+export type Gift = {
+  giftId: number;
+  productId: number;
+  name: string;
+  brandName: string;
+  photo: string;
+  senderName: string;
+  receivedDate: string;
+  expiredDate: string;
+  status: 'unused' | 'finish' | 'cancel';
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #189

## 📝작업 내용

- 선물함 페이지 - 사용완료 탭 구현
![image](https://github.com/KakaoFunding/front-end/assets/82873315/63e50831-462a-4387-ba10-4a1bcffdead8)


- 사용한 선물이 없는 경우 EmptyItem 컴포넌트 띄우기
![image](https://github.com/KakaoFunding/front-end/assets/82873315/1b41cfca-07ca-4229-bafc-f7525eae5bc7)


## 🙏리뷰 요구사항

- 탭 위에 헤더 문구는 '사용가능 탭' 구현하면서 진행하겠습니다.
- 선물 아이템 컴포넌트를 사용해야 해서 `feat/193` 브랜치에서 분기하여 작업했습니다. `feat/193` 브랜치가 머지되면 자동으로 브랜치가 `dev`를 향하도록 변경되는 점 참고해주세요.
- (이슈 번호를 잘못 매겨서 커밋, 브랜치명 수정해서 다시 올립니다..!)