### PR TITLE
[feat]: 위시 페이지 레이아웃 구현(#194)

### DIFF
--- a/src/pages/MyPage/Wish/index.module.scss
+++ b/src/pages/MyPage/Wish/index.module.scss
@@ -1,0 +1,9 @@
+@import 'styles/mixins.module';
+
+.title {
+  @include font(28px, 800);
+
+  margin: 40px 0 30px;
+  line-height: 38px;
+  white-space: pre-line;
+}

--- a/src/pages/MyPage/Wish/index.tsx
+++ b/src/pages/MyPage/Wish/index.tsx
@@ -1,5 +1,27 @@
+import EmptyItem from 'components/feature/EmptyItem';
+
+import styles from './index.module.scss';
+
+const data = {
+  userName: '보경',
+  hasWish: true,
+};
+
 const Wish = () => {
-  return <>위시</>;
+  return (
+    <>
+      <div className={styles.title}>{`${data.userName}님의 \n위시리스트`}</div>
+      {data.hasWish ? (
+        <ul>
+          <li>위시 1</li>
+          <li>위시 2</li>
+          <li>위시 3</li>
+        </ul>
+      ) : (
+        <EmptyItem type="wish" />
+      )}
+    </>
+  );
 };
 
 export default Wish;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #194

## 📝작업 내용
- 위시 페이지 기본 레이아웃 구현
![image](https://github.com/KakaoFunding/front-end/assets/79066587/6c08c1c9-1746-4705-a6cf-96e641b31e7e)



## 🙏리뷰 요구사항
