### PR TITLE
Feat/225

### DIFF
--- a/src/components/feature/PaymentItem/index.tsx
+++ b/src/components/feature/PaymentItem/index.tsx
@@ -1,28 +1,29 @@
+import { ResponseFundingPreview } from 'types/payment';
+
 import styles from './index.module.scss';
 
-// TODO : 필요 데이터
-const data = {
-  src: 'https://img1.kakaocdn.net/thumb/C86x86@2x.fwebp.q82/?fname=https%3A%2F%2Fst.kakaocdn.net%2Fproduct%2Fgift%2Fproduct%2F20231120093525_68d33ddb2c0e426786589e6d47319a7d.jpg',
-  brandName: '탬버린즈',
-  title: '"NEW 펌키니" [단독/선물포장] 미니 퍼퓸 핸드크림',
-  option: '옵션[NEW] PUMKINI #크리미 #제니PICK #카카오단독 | THANK YOU',
-};
+type PaymentItemProps = Omit<ResponseFundingPreview, 'amount'>;
 
-const PaymentItem = () => {
+const PaymentItem = ({
+  name,
+  brandName,
+  photo,
+  optionNames,
+}: PaymentItemProps) => {
   return (
     <section className={styles.wrapper_item}>
       <img
-        src={data.src}
-        alt={`${data.title}상품이미지`}
+        src={photo}
+        alt={`${name}상품이미지`}
         className={styles.thumb_item}
       />
       <div>
-        <p className={styles.txt_brand}>{data.brandName}</p>
-        <p className={styles.txt_title}>{data.title}</p>
-        {data.option && (
+        <p className={styles.txt_brand}>{brandName}</p>
+        <p className={styles.txt_title}>{name}</p>
+        {optionNames && (
           <p className={styles.txt_option}>
             <span className={styles.ico_option} />
-            {data.option}
+            {optionNames?.join(' | ')}
           </p>
         )}
       </div>

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -7,6 +7,7 @@ type ButtonProps = {
   color?: 'white' | 'gray' | 'black' | 'yellow';
   onClick?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
   className?: string;
+  disabled?: boolean;
   children: React.ReactNode;
 };
 
@@ -14,6 +15,7 @@ export const Button = ({
   color,
   onClick,
   className,
+  disabled,
   children,
 }: ButtonProps) => {
   return (
@@ -21,6 +23,7 @@ export const Button = ({
       type="button"
       className={clsx(styles.btn_default, color && styles[color], className)}
       onClick={onClick}
+      disabled={disabled}
     >
       {children}
     </button>

--- a/src/components/ui/Modal/FundingCancelModal/index.module.scss
+++ b/src/components/ui/Modal/FundingCancelModal/index.module.scss
@@ -25,16 +25,15 @@
   .wrapper_cancel {
     display: flex;
 
-    .ico_cancel_active {
-      @include ico-layer(-195px, -20px, 18px, 18px);
+    .checkbox_cancel {
+      margin: 0 4px 0 0;
+      appearance: none;
 
-      margin-right: 4px;
-    }
-
-    .ico_cancel {
       @include ico-layer(-195px, 0, 18px, 18px);
 
-      margin-right: 4px;
+      &:checked {
+        @include ico-layer(-195px, -20px, 18px, 18px);
+      }
     }
   }
 

--- a/src/components/ui/Modal/FundingCancelModal/index.module.scss
+++ b/src/components/ui/Modal/FundingCancelModal/index.module.scss
@@ -41,14 +41,13 @@
   .btn_cancel {
     margin: 20px 0 0;
     height: 40px;
-    color: #999;
-    background-color: #e5e5e5;
-    cursor: auto;
+    color: #000;
+    background-color: $point-yellow;
 
-    &.on {
-      color: #000;
-      background-color: $point-yellow;
-      cursor: pointer;
+    &:disabled {
+      color: #999;
+      background-color: #e5e5e5;
+      cursor: default;
     }
   }
 }

--- a/src/components/ui/Modal/FundingCancelModal/index.tsx
+++ b/src/components/ui/Modal/FundingCancelModal/index.tsx
@@ -3,20 +3,30 @@ import { useEffect, useState } from 'react';
 import { Button } from 'components/ui/Button';
 import Modal from 'components/ui/Modal';
 
+import { useAxios } from 'hooks/useAxios';
+
 import { FriendsSelectorModalProps } from 'types/modal';
 
 import styles from './index.module.scss';
 
 const FundingCancelModal = ({
+  fundingId,
   close,
   isOpen,
   scrollPos,
-}: FriendsSelectorModalProps) => {
+}: { fundingId: number } & FriendsSelectorModalProps) => {
   const [checked, setChecked] = useState(false);
+  const { sendRequest } = useAxios({
+    method: 'post',
+    url: '/funding/payments/cancel',
+    data: {
+      fundingId,
+    },
+  });
 
   const handleCheck = () => setChecked(!checked);
-  const handleCancel = () => {
-    // 펀딩 취소 로직
+  const handleCancel = async () => {
+    await sendRequest();
     close();
   };
 

--- a/src/components/ui/Modal/FundingCancelModal/index.tsx
+++ b/src/components/ui/Modal/FundingCancelModal/index.tsx
@@ -35,8 +35,7 @@ const FundingCancelModal = ({
       >
         <strong className={styles.txt_title}>펀딩 취소</strong>
         <p className={styles.txt_desc}>
-          {`펀딩을 취소하면 모든 펀딩 금액이 펀딩에 참여한 친구들에게 환불돼요. 취소한 펀딩은
-          복구할 수 없어요. \n\n정말로 펀딩을 취소하시겠어요?`}
+          {`펀딩을 취소하면 모든 펀딩 금액이 펀딩에 참여한 친구들에게 환불돼요. 취소한 펀딩은 복구할 수 없어요.\n\n정말로 펀딩을 취소하시겠어요?`}
         </p>
         <span className={styles.wrapper_cancel} onClick={handleCheck}>
           <span

--- a/src/components/ui/Modal/FundingCancelModal/index.tsx
+++ b/src/components/ui/Modal/FundingCancelModal/index.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 
 import { Button } from 'components/ui/Button';
@@ -36,15 +35,19 @@ const FundingCancelModal = ({
         <p className={styles.txt_desc}>
           {`펀딩을 취소하면 모든 펀딩 금액이 펀딩에 참여한 친구들에게 환불돼요. 취소한 펀딩은 복구할 수 없어요.\n\n정말로 펀딩을 취소하시겠어요?`}
         </p>
-        <span className={styles.wrapper_cancel} onClick={handleCheck}>
-          <span
-            className={clsx({
-              [styles.ico_cancel_active]: checked,
-              [styles.ico_cancel]: !checked,
-            })}
+        <label
+          htmlFor="cancelFundingConfirmation"
+          className={styles.wrapper_cancel}
+        >
+          <input
+            type="checkbox"
+            id="cancelFundingConfirmation"
+            className={styles.checkbox_cancel}
+            checked={checked}
+            onChange={handleCheck}
           />
           펀딩을 취소합니다.
-        </span>
+        </label>
         <Button
           onClick={handleCancel}
           className={styles.btn_cancel}

--- a/src/components/ui/Modal/FundingCancelModal/index.tsx
+++ b/src/components/ui/Modal/FundingCancelModal/index.tsx
@@ -17,7 +17,6 @@ const FundingCancelModal = ({
 
   const handleCheck = () => setChecked(!checked);
   const handleCancel = () => {
-    if (!checked) return;
     // 펀딩 취소 로직
     close();
   };
@@ -48,7 +47,8 @@ const FundingCancelModal = ({
         </span>
         <Button
           onClick={handleCancel}
-          className={clsx(styles.btn_cancel, { [styles.on]: checked })}
+          className={styles.btn_cancel}
+          disabled={!checked}
         >
           펀딩 취소하기
         </Button>

--- a/src/components/ui/Modal/FundingModal/index.tsx
+++ b/src/components/ui/Modal/FundingModal/index.tsx
@@ -29,7 +29,7 @@ const FundingModal = ({
   scrollPos,
 }: FriendsSelectorModalProps) => {
   const {
-    fundingAmount: goalAmount,
+    input: goalAmount,
     remainingAmount,
     clearInput,
     handleChange,
@@ -50,7 +50,7 @@ const FundingModal = ({
   };
 
   useEffect(() => {
-    clearInput(mockData.price);
+    clearInput();
   }, [isOpen]);
 
   return (

--- a/src/components/ui/Modal/FundingModal/index.tsx
+++ b/src/components/ui/Modal/FundingModal/index.tsx
@@ -5,30 +5,49 @@ import Thumbnail from 'components/feature/ProductItem/Thumbnail';
 import { Button } from 'components/ui/Button';
 import Modal from 'components/ui/Modal';
 
+import { useAxios } from 'hooks/useAxios';
 import useFundingInput from 'hooks/useFundingInput';
-import { formatNumberWithUnit } from 'utils/format';
+import { formatDate, formatNumberWithUnit } from 'utils/format';
+import { getOneYearLaterDate } from 'utils/generate';
 
 import { FriendsSelectorModalProps } from 'types/modal';
 
 import styles from './index.module.scss';
 
 const mockData = {
+  productId: 1,
   title: '[각인+포장] 리브르 헤어 미스트 30ml 세트(+향수 미니어처 7.5ml)',
   option: '940 코쿤 [New & Limited]',
   thumbImgUrl:
     'https://img1.kakaocdn.net/thumb/C320x320@2x.fwebp.q82/?fname=https%3A%2F%2Fst.kakaocdn.net%2Fproduct%2Fgift%2Fproduct%2F20220111185052_b92447cb764d470ead70b2d0fe75fe5c.jpg',
   price: 3940000,
 };
+
 const FundingModal = ({
   close,
   isOpen,
   scrollPos,
 }: FriendsSelectorModalProps) => {
-  const { fundingAmount, clearInput, remainingAmount, handleChange } =
-    useFundingInput(mockData.price);
+  const {
+    fundingAmount: goalAmount,
+    remainingAmount,
+    clearInput,
+    handleChange,
+  } = useFundingInput(mockData.price);
 
-  // TODO : 펀딩등록로직추가
-  const handleAddFunding = close;
+  const { sendRequest } = useAxios<{ id: number }>({
+    method: 'post',
+    url: `/funding/${mockData.productId}`,
+    data: {
+      goalAmount,
+      expiredAt: formatDate(getOneYearLaterDate()),
+    },
+  });
+
+  const handleAddFunding = async () => {
+    await sendRequest();
+    close();
+  };
 
   useEffect(() => {
     clearInput(mockData.price);
@@ -84,7 +103,7 @@ const FundingModal = ({
             <input
               className={styles.input}
               onChange={handleChange}
-              value={fundingAmount}
+              value={goalAmount}
               placeholder="0"
             />
             원

--- a/src/hooks/useFundingInput.ts
+++ b/src/hooks/useFundingInput.ts
@@ -3,27 +3,35 @@ import { useState, ChangeEvent } from 'react';
 import { formatNumberWithComma } from 'utils/format';
 import { isValidPrice } from 'utils/validation';
 
-const useFundingInput = (goalFundingPrice: number) => {
-  const [fundingAmount, setFundingAmount] = useState<string>('');
+const useFundingInput = (maxFundingAmount: number) => {
+  const [input, setInput] = useState<string>('0');
   const [remainingAmount, setRemainingAmount] =
-    useState<number>(goalFundingPrice);
+    useState<number>(maxFundingAmount);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value.split(',').join('');
     if (!isValidPrice(inputValue)) return;
 
-    const newRemainingAmount = Number(inputValue);
-    if (newRemainingAmount > goalFundingPrice) return;
-    setFundingAmount(formatNumberWithComma(newRemainingAmount));
-    setRemainingAmount(goalFundingPrice - newRemainingAmount);
+    let newInputValue = Number(inputValue);
+    if (newInputValue > maxFundingAmount) {
+      newInputValue = maxFundingAmount;
+    }
+    setInput(formatNumberWithComma(newInputValue));
+    setRemainingAmount(maxFundingAmount - newInputValue);
   };
 
-  const clearInput = (price: number) => {
-    setFundingAmount('');
-    setRemainingAmount(price);
+  const clearInput = () => {
+    setInput('0');
+    setRemainingAmount(maxFundingAmount);
   };
 
-  return { fundingAmount, remainingAmount, clearInput, handleChange };
+  return {
+    input,
+    remainingAmount,
+    setRemainingAmount,
+    clearInput,
+    handleChange,
+  };
 };
 
 export default useFundingInput;

--- a/src/hooks/useFundingInput.ts
+++ b/src/hooks/useFundingInput.ts
@@ -28,7 +28,6 @@ const useFundingInput = (maxFundingAmount: number) => {
   return {
     input,
     remainingAmount,
-    setRemainingAmount,
     clearInput,
     handleChange,
   };

--- a/src/layouts/FundingPayment/FundingDetail/index.tsx
+++ b/src/layouts/FundingPayment/FundingDetail/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import PaymentItem from 'components/feature/PaymentItem';
+import Spinner from 'components/ui/Spinner';
 
 import { useAxios } from 'hooks/useAxios';
 import { formatNumberWithComma } from 'utils/format';
@@ -51,15 +52,23 @@ const FundingDetail = ({ fundingId, setFundingAmount }: FundingDetailProps) => {
     setInput(formatNumberWithComma(newFundingAmount));
   };
 
+  if (!data) return <Spinner />;
+
   return (
     <section className={styles.area_funding_detail}>
       <strong className={styles.txt_title}>펀딩내역</strong>
       <div className={styles.wrapper_funding_item}>
-        <PaymentItem />
+        <PaymentItem
+          productId={data.productId}
+          name={data.name}
+          brandName={data.brandName}
+          photo={data.photo}
+          optionNames={data.optionNames}
+        />
         <p className={styles.wrapper_desc}>
           <span className={styles.txt_price}>펀딩 목표 금액</span>
           <span className={styles.num_price}>
-            {formatNumberWithComma(data?.amount?.goalAmount ?? 0)}
+            {formatNumberWithComma(data.amount.goalAmount ?? 0)}
           </span>
           원
         </p>

--- a/src/layouts/GiftPayment/GiftDetail/GiftItem/index.tsx
+++ b/src/layouts/GiftPayment/GiftDetail/GiftItem/index.tsx
@@ -13,12 +13,27 @@ const data = {
   headCount: 1,
 };
 
+const previewData = {
+  productId: 222,
+  photo:
+    'https://img1.kakaocdn.net/thumb/C86x86@2x.fwebp.q82/?fname=https%3A%2F%2Fst.kakaocdn.net%2Fproduct%2Fgift%2Fproduct%2F20231120093525_68d33ddb2c0e426786589e6d47319a7d.jpg',
+  brandName: '탬버린즈',
+  name: '"NEW 펌키니" [단독/선물포장] 미니 퍼퓸 핸드크림',
+  optionNames: ['[NEW] PUMKINI #크리미 #제니PICK #카카오단독', 'THANK YOU'],
+};
+
 const GiftItem = () => {
   const [isToggled, handleToggle] = useReducer((prev) => !prev, false);
 
   return (
     <div className={styles.wrapper_item}>
-      <PaymentItem />
+      <PaymentItem
+        productId={previewData.productId}
+        name={previewData.name}
+        brandName={previewData.brandName}
+        photo={previewData.photo}
+        optionNames={previewData.optionNames}
+      />
       <button
         className={styles.btn_payment}
         type="button"

--- a/src/layouts/MyPage/Funding/FundingItem/index.tsx
+++ b/src/layouts/MyPage/Funding/FundingItem/index.tsx
@@ -10,6 +10,7 @@ import styles from './index.module.scss';
 
 // TODO : 펀딩 API 확인후 분리 예정
 type FundingItemProps = {
+  fundingId: number;
   imgUrl: string;
   price: number;
   productName: string;
@@ -20,6 +21,7 @@ type FundingItemProps = {
 };
 
 const FundingItem = ({
+  fundingId,
   imgUrl,
   price,
   productName,
@@ -32,7 +34,12 @@ const FundingItem = ({
 
   return (
     <section className={styles.area_funding_item}>
-      <FundingCancelModal isOpen={isOpen} close={close} scrollPos={scrollPos} />
+      <FundingCancelModal
+        fundingId={fundingId}
+        isOpen={isOpen}
+        close={close}
+        scrollPos={scrollPos}
+      />
       <Link to={`/product/${productId}`}>
         {/* TODO : Thumbnail 리팩토링시 교체 */}
         <img

--- a/src/mocks/fundingHandler.ts
+++ b/src/mocks/fundingHandler.ts
@@ -1,10 +1,28 @@
 import { HttpResponse, PathParams, http } from 'msw';
 
+import { ResponseFundingPreview } from 'types/payment';
+
 type RequestAddFunding = {
   goalAmount: number;
 };
 
 export const fundingHandlers = [
+  // 펀딩 결제 내역 프리뷰
+  http.post('/funding/preview', async () => {
+    return HttpResponse.json<ResponseFundingPreview>({
+      productId: 2274,
+      name: '[선물포장] 베르사체 에로스 30ML + 에로스 미니어처 5ML',
+      photo:
+        'https://st.kakaocdn.net/product/gift/product/20240220155008_b20dcecc7a484754ad1e75854794e192.png',
+      optionNames: null,
+      amount: {
+        totalAmount: 41700,
+        goalAmount: 41700,
+        remainAmount: 31700,
+      },
+    });
+  }),
+
   // 펀딩 아이템 등록(펀딩 개설)
   http.post<PathParams, RequestAddFunding>(
     '/funding/:productId',

--- a/src/mocks/fundingHandler.ts
+++ b/src/mocks/fundingHandler.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, PathParams, http } from 'msw';
+import { HttpResponse, PathParams, delay, http } from 'msw';
 
 import { ResponseFundingPreview } from 'types/payment';
 
@@ -9,9 +9,12 @@ type RequestAddFunding = {
 export const fundingHandlers = [
   // 펀딩 결제 내역 프리뷰
   http.post('/funding/preview', async () => {
+    await delay();
+
     return HttpResponse.json<ResponseFundingPreview>({
       productId: 2274,
       name: '[선물포장] 베르사체 에로스 30ML + 에로스 미니어처 5ML',
+      brandName: '베르사체',
       photo:
         'https://st.kakaocdn.net/product/gift/product/20240220155008_b20dcecc7a484754ad1e75854794e192.png',
       optionNames: null,

--- a/src/mocks/fundingHandler.ts
+++ b/src/mocks/fundingHandler.ts
@@ -1,6 +1,26 @@
-import { HttpResponse, http } from 'msw';
+import { HttpResponse, PathParams, http } from 'msw';
+
+type RequestAddFunding = {
+  goalAmount: number;
+};
 
 export const fundingHandlers = [
+  // 펀딩 아이템 등록(펀딩 개설)
+  http.post<PathParams, RequestAddFunding>(
+    '/funding/:productId',
+    async ({ request }) => {
+      const data = await request.json();
+
+      if (data?.goalAmount <= 0) {
+        return new HttpResponse(null, {
+          status: 400,
+        });
+      }
+
+      return HttpResponse.json({ id: 1 });
+    },
+  ),
+
   // 개설한 펀딩 취소
   http.post('/funding/payments/cancel', async () => {
     return new HttpResponse(null, {

--- a/src/mocks/fundingHandler.ts
+++ b/src/mocks/fundingHandler.ts
@@ -1,0 +1,10 @@
+import { HttpResponse, http } from 'msw';
+
+export const fundingHandlers = [
+  // 개설한 펀딩 취소
+  http.post('/funding/payments/cancel', async () => {
+    return new HttpResponse(null, {
+      status: 200,
+    });
+  }),
+];

--- a/src/mocks/worker.ts
+++ b/src/mocks/worker.ts
@@ -2,6 +2,7 @@ import { setupWorker } from 'msw/browser';
 
 import { brandHandlers } from './brandHandler';
 import { categoriesHandlers } from './categoriesHandler';
+import { fundingHandlers } from './fundingHandler';
 import { giftHandlers } from './giftHandler';
 import { paymentHandlers } from './paymentHandler';
 import { productHandlers } from './productHandler';
@@ -13,6 +14,7 @@ const handlers = [
   ...brandHandlers,
   ...paymentHandlers,
   ...giftHandlers,
+  ...fundingHandlers,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -1,14 +1,18 @@
+import { useState } from 'react';
+
 import MessageCard from 'components/feature/MessageCard';
 import PaymentDetail from 'components/feature/PaymentDetail';
 import MainWrapper from 'components/ui/MainWrapper';
 import FundingDetail from 'layouts/FundingPayment/FundingDetail';
 
-import { useInput } from 'hooks/useInput';
-
 import styles from './index.module.scss';
 
+const data = {
+  fundingId: 1,
+};
+
 const FundingPayment = () => {
-  const { value } = useInput('0');
+  const [fundingAmount, setFundingAmount] = useState<number>(0);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -19,9 +23,12 @@ const FundingPayment = () => {
       <form className={styles.wrapper_form} onSubmit={handleSubmit}>
         <div className={styles.area_field}>
           <MessageCard />
-          <FundingDetail />
+          <FundingDetail
+            fundingId={data.fundingId}
+            setFundingAmount={setFundingAmount}
+          />
         </div>
-        <PaymentDetail totalPrice={Number(value)} />
+        <PaymentDetail totalPrice={fundingAmount} />
       </form>
     </MainWrapper>
   );

--- a/src/pages/MyPage/Funding/index.tsx
+++ b/src/pages/MyPage/Funding/index.tsx
@@ -7,6 +7,7 @@ import styles from './index.module.scss';
 const data = {
   hasFunding: true,
   userName: '보경',
+  fundingId: 1,
   imgUrl:
     'https://img1.kakaocdn.net/thumb/C320x320@2x.fwebp.q82/?fname=https%3A%2F%2Fst.kakaocdn.net%2Fproduct%2Fgift%2Fproduct%2F20240412000831_223be6cfd2eb40e3bbaf238fca8a56e9',
   fundingItemName: '참이 포함된 트레이드마크 체인 팔찌',
@@ -24,6 +25,7 @@ const Funding = () => {
       <div className={styles.title}>{`${data.userName}님의 \n펀딩아이템`}</div>
       {data.hasFunding ? (
         <FundingItem
+          fundingId={data.fundingId}
           imgUrl={data.imgUrl}
           price={data.fundingPrice}
           productName={data.fundingItemName}

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -12,6 +12,7 @@ export type ResponseExpectedPaymentAmount = {
 export type ResponseFundingPreview = {
   productId: number;
   name: string;
+  brandName: string;
   photo: string;
   optionNames: string[] | null;
   amount: {

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -8,3 +8,15 @@ export type ResponseExpectedPaymentAmount = {
   methods: string[];
   totalProductAmount: number;
 };
+
+export type ResponseFundingPreview = {
+  productId: number;
+  name: string;
+  photo: string;
+  optionNames: string[] | null;
+  amount: {
+    totalAmount: number;
+    goalAmount: number;
+    remainAmount: number;
+  };
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -23,3 +23,16 @@ export const formatNumberToPercent = (
   const percent = (numerator / denominator) * 100;
   return `${percent.toFixed(1)}%`;
 };
+
+/**
+ * Format date as yyyy-mm-dd
+ * @param date date to format
+ * @returns formatted date (yyyy-mm-dd)
+ */
+export const formatDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = date.toLocaleDateString('default', { month: '2-digit' });
+  const day = date.toLocaleDateString('default', { day: '2-digit' });
+
+  return `${year}-${month}-${day}`;
+};

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -1,3 +1,13 @@
 export function getRandomNumber(start: number, end: number): number {
   return Math.floor(start + Math.random() * end);
 }
+
+export const getOneYearLaterDate = () => {
+  const currentDate = new Date();
+  const oneYearLaterDate = new Date(
+    currentDate.getFullYear() + 1,
+    currentDate.getMonth(),
+    currentDate.getDate(),
+  );
+  return oneYearLaterDate;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #225

## 📝작업 내용

- 펀딩 페이지 - 개설한 펀딩 취소 API 연동
- 펀딩 등록 모달 - 펀딩 등록 API 연동
- 펀딩 결제 페이지 - 펀딩 상세 내역 API 연동

## 🙏리뷰 요구사항

- 결제 API는 시간이 좀 더 필요할 것 같기도 하고, 이미 양이 많아서 분리해서 올리면 좋을 것 같아서 완료한 작업들만 올립니다.
- API가 인증된 유저만 요청 가능해야 해서 토큰도 같이 보내야 하는데, 이거는 axios 인스턴스를 하나 만드는 게 좋을 것 같아서 이슈 만들고 작업하는 게 좋을 듯 합니다.
- 비슷하게 인증된 유저만 접근 가능하도록 하는 라우트도 이슈 만들어서 작업해야 할 것 같아욥
- 펀딩 결제페이지의 펀딩내역 부분은 `useFundingInput`을 안쓰고 구현했는데요. 이유는 요 [커밋](https://github.com/KakaoFunding/front-end/commit/71fd3cb0f299475f9815bb7ed2df11b360f0bcef) 내용 부분에 자세히 적혀있습니다. 재사용성 높은 코드를 짜기란 참 어려운 것 같다는 걸 항상 느끼네요... ㅜㅜ