### PR TITLE
Fix/245

### DIFF
--- a/src/components/feature/ProductItem/CartButton/index.tsx
+++ b/src/components/feature/ProductItem/CartButton/index.tsx
@@ -1,12 +1,8 @@
 import { MouseEvent } from 'react';
 
-import { ProductItem } from 'types/productItem';
-
 import styles from './index.module.scss';
 
-type CartButtonProps = { id: ProductItem['productId'] };
-
-const CartButton = ({ id }: CartButtonProps) => {
+const CartButton = () => {
   // TODO : API 요청
   const handleAddCart = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/src/components/feature/ProductItem/ColumnProductItem/index.tsx
+++ b/src/components/feature/ProductItem/ColumnProductItem/index.tsx
@@ -27,12 +27,8 @@ const ColumnProductItem = ({ product, size }: ColumnProductItemProps) => {
         </div>
       </Link>
       <div className={styles.wrapper_util_info}>
-        <CartButton id={product.productId} />
-        <WishButton
-          id={product.productId}
-          isWished={product.wished}
-          wishCount={product.wishCount}
-        />
+        <CartButton />
+        <WishButton isWished={product.wished} wishCount={product.wishCount} />
       </div>
     </article>
   );

--- a/src/components/feature/ProductItem/WishButton/index.tsx
+++ b/src/components/feature/ProductItem/WishButton/index.tsx
@@ -8,12 +8,11 @@ import { ProductItem } from 'types/productItem';
 import styles from './index.module.scss';
 
 type WishButtonProps = {
-  id: ProductItem['productId'];
   isWished: ProductItem['wished'];
   wishCount: ProductItem['wishCount'];
 };
 
-const WishButton = ({ id, isWished, wishCount }: WishButtonProps) => {
+const WishButton = ({ isWished, wishCount }: WishButtonProps) => {
   const DIVIDER = 10000;
   const REMAINS = '만+';
 

--- a/src/layouts/Home/Receiver/FriendWish/FriendWishItem/index.tsx
+++ b/src/layouts/Home/Receiver/FriendWish/FriendWishItem/index.tsx
@@ -28,9 +28,8 @@ const FriendWishItem = ({ product }: { product: ProductItem }) => {
               <span className={styles.txt_unit}>원</span>
             </p>
             <div className={styles.wrapper_btn}>
-              <CartButton id={product.productId} />
+              <CartButton />
               <WishButton
-                id={product.productId}
                 isWished={product.wished}
                 wishCount={product.wishCount}
               />

--- a/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
+++ b/src/layouts/MyPage/GiftBox/UnavailableGiftTab/index.tsx
@@ -59,6 +59,7 @@ const UnavailableGiftTab = () => {
               photo={gift.photo}
               senderName={gift.senderName}
               receivedDate={gift.receivedDate}
+              expiredDate={gift.expiredDate}
               status={gift.status}
             />
           </li>

--- a/src/layouts/Product/DetailBottom/ProductItem.tsx
+++ b/src/layouts/Product/DetailBottom/ProductItem.tsx
@@ -9,7 +9,12 @@ import { ProductItem as ProductItemType } from 'types/productItem';
 
 import styles from './ProductItem.module.scss';
 
-const ProductItem = ({ productId, photo, name, price }: ProductItemType) => {
+type ProductItemProps = Pick<
+  ProductItemType,
+  'productId' | 'photo' | 'name' | 'price'
+>;
+
+const ProductItem = ({ productId, photo, name, price }: ProductItemProps) => {
   return (
     <article className={clsx(styles.wrapper_prod_item)}>
       <Link to={`/product/${productId}`} className={styles.wrapper_main_info}>

--- a/src/layouts/Product/DetailBottom/ProductItem.tsx
+++ b/src/layouts/Product/DetailBottom/ProductItem.tsx
@@ -18,7 +18,7 @@ const ProductItem = ({ productId, photo, name, price }: ProductItemType) => {
         <Price price={price} />
       </Link>
       <div className={styles.wrapper_util_info}>
-        <CartButton id={productId} />
+        <CartButton />
       </div>
     </article>
   );

--- a/src/layouts/Product/DetailBottom/index.tsx
+++ b/src/layouts/Product/DetailBottom/index.tsx
@@ -65,7 +65,12 @@ const DetailBottom = ({ brandId }: DetailBottomProps) => {
         <ul className={styles.area_products}>
           {mockProducts.map((product) => (
             <li key={product.id} className={styles.wrapper_item}>
-              <ProductItem product={product} />
+              <ProductItem
+                productId={product.id}
+                name={product.name}
+                photo={product.thumbSrc}
+                price={product.price}
+              />
             </li>
           ))}
         </ul>

--- a/src/stories/ColumnProductItem.stories.tsx
+++ b/src/stories/ColumnProductItem.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import ColumnProductItem from 'components/feature/ProductItem/ColumnProductItem';
 
+import { ProductItem } from 'types/productItem';
+
 const meta: Meta<typeof ColumnProductItem> = {
   component: ColumnProductItem,
   title: 'ProductItem/Column',
@@ -12,14 +14,14 @@ export default meta;
 type Story = StoryObj<typeof ColumnProductItem>;
 
 // 임시 상품 아이템 데이터
-const productData = {
-  id: 1,
-  thumbSrc:
+const productData: ProductItem = {
+  productId: 1,
+  photo:
     'https://img1.kakaocdn.net/thumb/C320x320@2x.fwebp.q82/?fname=https%3A%2F%2Fst.kakaocdn.net%2Fproduct%2Fgift%2Fproduct%2F20200404101217_091a18bd9a024799ad6d9018f1035614',
   brandName: '설빙',
   name: '오레오초코몬스터설빙',
   price: 12900,
-  isWished: true,
+  wished: true,
   wishCount: 6008,
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #245

## 📝작업 내용

- 상품아이템 - 위시버튼 props에서 사용하지 않는 id 제거
- 상품아이템 - 장바구니버튼 props에서 사용하지 않는 id 제거
- 선물함 페이지 - 사용완료 탭 사용 시, 선언한 props와 일치하는 데이터 전달하도록 변경
- 상품상세조회 페이지 - detailBottom - 상품아이템 props 타입을 변경 (사용하는 데이터만 prop으로 받도록 명시함)
- ColumnProductItem Story에서 argument로 전달되는 데이터가 해당 컴포넌트의 Props 타입과 일치하도록 변경

## 🙏리뷰 요구사항

- 다른 분들께서 작업하신 부분도 함께 수정하였으니, 잘 수정된 게 맞는지 확인 부탁드립니다.
- 머지 이후에 다른 브랜치에서 작업중인 것을 머지할 때 충돌 또는 잘못된 덮어쓰기 등이 일어나지 않도록 주의해주세요 !