### PR TITLE
[feat]:주문내역 페이지 레이아웃 구현 (#229)

### DIFF
--- a/src/pages/MyPage/OrderHistory/index.module.scss
+++ b/src/pages/MyPage/OrderHistory/index.module.scss
@@ -1,0 +1,9 @@
+@import 'styles/mixins.module';
+
+.title {
+  @include font(28px, 800);
+
+  margin: 40px 0 30px;
+  line-height: 38px;
+  white-space: pre-line;
+}

--- a/src/pages/MyPage/OrderHistory/index.tsx
+++ b/src/pages/MyPage/OrderHistory/index.tsx
@@ -1,5 +1,20 @@
+import styles from './index.module.scss';
+
+const data = {
+  userName: '보경',
+};
+
 const OrderHistory = () => {
-  return <>주문내역</>;
+  return (
+    <>
+      <div className={styles.title}>{`${data.userName}님의 \n주문내역`}</div>
+      <ul>
+        <li>주문내역1</li>
+        <li>주문내역2</li>
+        <li>주문내역3</li>
+      </ul>
+    </>
+  );
 };
 
 export default OrderHistory;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #229

## 📝작업 내용
- 주문내역 페이지 레이아웃 구현
![image](https://github.com/KakaoFunding/front-end/assets/79066587/d203817e-bd8a-4ddb-b7ef-ff2558a158b7)


## 🙏리뷰 요구사항(선택)
