### PR TITLE
Feat/238

### DIFF
--- a/src/components/feature/PaymentDetail/index.module.scss
+++ b/src/components/feature/PaymentDetail/index.module.scss
@@ -105,4 +105,10 @@
   text-align: center;
 
   @include font(18px, 700);
+
+  &:disabled {
+    color: #999;
+    background-color: #e5e5e5;
+    cursor: default;
+  }
 }

--- a/src/components/feature/PaymentDetail/index.tsx
+++ b/src/components/feature/PaymentDetail/index.tsx
@@ -20,7 +20,12 @@ const PaymentDetail = ({ totalPrice }: PaymentDetailProps) => {
           <div className={styles.wrapper_kakao}>
             <span className={styles.ico_kakao}>카카오페이 아이콘</span>
             <label htmlFor="KAKAO_PAY">
-              <input type="radio" id="KAKAO_PAY" name={PAY_METHOD} checked />
+              <input
+                type="radio"
+                id="KAKAO_PAY"
+                name={PAY_METHOD}
+                defaultChecked
+              />
               <span className={styles.txt_method}>카카오페이</span>
             </label>
           </div>

--- a/src/components/feature/PaymentDetail/index.tsx
+++ b/src/components/feature/PaymentDetail/index.tsx
@@ -40,7 +40,11 @@ const PaymentDetail = ({ totalPrice }: PaymentDetailProps) => {
           </span>
         </div>
 
-        <button type="submit" className={styles.btn_pay}>
+        <button
+          type="submit"
+          className={styles.btn_pay}
+          disabled={totalPrice === 0}
+        >
           {formatNumberWithUnit(totalPrice)} 결제하기
         </button>
       </fieldset>

--- a/src/layouts/Home/Receiver/FriendFunding/index.tsx
+++ b/src/layouts/Home/Receiver/FriendFunding/index.tsx
@@ -12,6 +12,7 @@ import styles from './index.module.scss';
 // TODO : 데이터 페칭시 변수명 수정
 // 펀딩아이템의 총금액이 아닌 펀딩목표금액
 const data = {
+  fundingId: 11,
   thumbnail:
     'https://img1.kakaocdn.net/thumb/C320x320@2x.fwebp.q82/?fname=https%3A%2F%2Fst.kakaocdn.net%2Fproduct%2Fgift%2Fproduct%2F20240318095141_80a46f7dfcee4aecae72311ac9c52e7d.jpg',
   brand: '스타벅스',
@@ -58,11 +59,7 @@ const FriendFunding = () => {
               denominator={data.productPrice}
               numerator={data.fundingPrice}
             />
-            {/* TODO : 결제페이지 props에 맞게 필요한 데이터 전달 */}
-            <Link
-              to="/bill/funding"
-              state={{ productId: data.productId, self: false }}
-            >
+            <Link to="/bill/funding" state={{ fundingId: data.fundingId }}>
               <Button color="yellow" className={styles.btn_funding}>
                 펀딩하기
               </Button>

--- a/src/layouts/MyPage/Funding/FundingItem/index.tsx
+++ b/src/layouts/MyPage/Funding/FundingItem/index.tsx
@@ -74,8 +74,7 @@ const FundingItem = ({
           <Button color="black" onClick={open} className={styles.btn_default}>
             펀딩취소하기
           </Button>
-          {/* TODO : 결제페이지 props에 맞게 필요한 데이터 전달 */}
-          <Link to="/bill/funding" state={{ productId, self: true }}>
+          <Link to="/bill/funding" state={{ fundingId }}>
             <Button color="yellow" className={styles.btn_default}>
               펀딩하기
             </Button>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,7 @@ import GiftBox from 'pages/MyPage/GiftBox';
 import OrderHistory from 'pages/MyPage/OrderHistory';
 import Wish from 'pages/MyPage/Wish';
 import NotFound from 'pages/NotFound';
+import PaymentCancel from 'pages/PaymentCancel';
 import PaymentFail from 'pages/PaymentFail';
 import Product from 'pages/Product';
 import Search from 'pages/Search';
@@ -115,6 +116,10 @@ const router = createBrowserRouter([
       {
         path: '/payment/fail',
         element: <PaymentFail />,
+      },
+      {
+        path: '/payment/cancel',
+        element: <PaymentCancel />,
       },
       { path: '/auth', element: <Auth /> },
       {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,7 @@ import GiftBox from 'pages/MyPage/GiftBox';
 import OrderHistory from 'pages/MyPage/OrderHistory';
 import Wish from 'pages/MyPage/Wish';
 import NotFound from 'pages/NotFound';
+import PaymentFail from 'pages/PaymentFail';
 import Product from 'pages/Product';
 import Search from 'pages/Search';
 import SearchResult from 'pages/SearchResult';
@@ -110,6 +111,10 @@ const router = createBrowserRouter([
       {
         path: '/funding/complete',
         element: <FundingComplete />,
+      },
+      {
+        path: '/payment/fail',
+        element: <PaymentFail />,
       },
       { path: '/auth', element: <Auth /> },
       {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import Auth from 'pages/Auth';
 import Brand from 'pages/Brand';
 import Cart from 'pages/Cart';
 import CategoryResult from 'pages/CategoryResult';
+import FundingComplete from 'pages/FundingComplete';
 import FundingPayment from 'pages/FundingPayment';
 import GiftPayment from 'pages/GiftPayment';
 import Home from 'pages/Home';
@@ -105,6 +106,10 @@ const router = createBrowserRouter([
       {
         path: '/bill/funding',
         element: <FundingPayment />,
+      },
+      {
+        path: '/funding/complete',
+        element: <FundingComplete />,
       },
       { path: '/auth', element: <Auth /> },
       {

--- a/src/mocks/fundingHandler.ts
+++ b/src/mocks/fundingHandler.ts
@@ -19,7 +19,7 @@ export const fundingHandlers = [
         'https://st.kakaocdn.net/product/gift/product/20240220155008_b20dcecc7a484754ad1e75854794e192.png',
       optionNames: null,
       amount: {
-        totalAmount: 41700,
+        productAmount: 41700,
         goalAmount: 41700,
         remainAmount: 31700,
       },

--- a/src/mocks/paymentHandler.ts
+++ b/src/mocks/paymentHandler.ts
@@ -1,9 +1,14 @@
-import { HttpResponse, PathParams, http } from 'msw';
+import { HttpResponse, PathParams, delay, http } from 'msw';
 
 import {
   RequestExpectedPaymentAmount,
+  RequestFundingReady,
   ResponseExpectedPaymentAmount,
+  ResponseFundingReady,
+  ResponseFundingSuccess,
 } from 'types/payment';
+
+let fundingAmount = 0;
 
 export const paymentHandlers = [
   http.post<
@@ -22,6 +27,45 @@ export const paymentHandlers = [
       shoppingPoint: 0,
       methods: ['KAKAO_PAY'],
       totalProductAmount: totalStock * 10000,
+    });
+  }),
+
+  // 펀딩 결제 준비
+  http.post<PathParams, RequestFundingReady, ResponseFundingReady>(
+    '/funding/payments/ready',
+    async ({ request }) => {
+      const data = await request.json();
+
+      const pgToken = `${data.fundingId}_${data.amount}`;
+      fundingAmount = data.amount;
+
+      await delay(1000);
+
+      return HttpResponse.json({
+        tid: '1',
+        redirectUrl: `http://localhost:5173/payments/success?pg_token=${pgToken}`,
+        orderNumber: '1',
+      });
+    },
+  ),
+
+  // 펀딩 결제 승인 - 성공
+  http.post('/funding/payments/success', async () => {
+    await delay(1000);
+
+    return HttpResponse.json<ResponseFundingSuccess>({
+      receiver: {
+        name: '김민우',
+        photoUrl:
+          'https://gift-s.kakaocdn.net/dn/gift/images/m640/bg_profile_default.png',
+      },
+      product: {
+        brandName: '남성향수',
+        photo:
+          'https://st.kakaocdn.net/product/gift/product/20240220155008_b20dcecc7a484754ad1e75854794e192.png',
+        name: '[선물포장] 베르사체 에로스 30ML + 에로스 미니어처 5ML',
+      },
+      attributeAmount: fundingAmount,
     });
   }),
 ];

--- a/src/pages/FundingComplete/index.tsx
+++ b/src/pages/FundingComplete/index.tsx
@@ -1,0 +1,9 @@
+// import { useLocation } from 'react-router-dom';
+
+const FundingComplete = () => {
+  // const { state } = useLocation();
+
+  return <div>FundingComplete</div>;
+};
+
+export default FundingComplete;

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import MessageCard from 'components/feature/MessageCard';
 import PaymentDetail from 'components/feature/PaymentDetail';
 import MainWrapper from 'components/ui/MainWrapper';
+import Spinner from 'components/ui/Spinner';
 import FundingDetail from 'layouts/FundingPayment/FundingDetail';
 
 import { useAxios } from 'hooks/useAxios';
@@ -19,6 +20,7 @@ const FundingPayment = () => {
 
   const [fundingAmount, setFundingAmount] = useState<number>(0);
   const [pgToken, setPgToken] = useState<string>('');
+  const [isPaying, setIsPaying] = useState<boolean>(false);
 
   // 결제 준비용 API
   const { data: readyData, sendRequest: sendReady } =
@@ -45,6 +47,7 @@ const FundingPayment = () => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setIsPaying(true);
     await sendReady();
   };
 
@@ -76,11 +79,13 @@ const FundingPayment = () => {
   useEffect(() => {
     if (!approveData) return;
 
+    setIsPaying(false);
     navigate('/funding/complete', { state: approveData });
   }, [approveData]);
 
   return (
     <MainWrapper>
+      {isPaying && <Spinner />}
       <form className={styles.wrapper_form} onSubmit={handleSubmit}>
         <div className={styles.area_field}>
           <MessageCard />

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import MessageCard from 'components/feature/MessageCard';
 import PaymentDetail from 'components/feature/PaymentDetail';
@@ -7,11 +8,11 @@ import FundingDetail from 'layouts/FundingPayment/FundingDetail';
 
 import styles from './index.module.scss';
 
-const data = {
-  fundingId: 1,
-};
 
 const FundingPayment = () => {
+  const { state } = useLocation();
+  const { fundingId }: { fundingId: number } = state;
+
   const [fundingAmount, setFundingAmount] = useState<number>(0);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -24,7 +25,7 @@ const FundingPayment = () => {
         <div className={styles.area_field}>
           <MessageCard />
           <FundingDetail
-            fundingId={data.fundingId}
+            fundingId={fundingId}
             setFundingAmount={setFundingAmount}
           />
         </div>

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -48,16 +48,12 @@ const FundingPayment = () => {
   // handle ready
   useEffect(() => {
     if (!readyData) return;
-
-    console.log(readyData);
     sendApprove();
   }, [readyData]);
 
   // handle success
   useEffect(() => {
     if (!approveData) return;
-
-    console.log(approveData);
     navigate('/funding/complete', { state: approveData });
   }, [approveData]);
 

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -20,6 +20,7 @@ const FundingPayment = () => {
   const [fundingAmount, setFundingAmount] = useState<number>(0);
   const [pgToken, setPgToken] = useState<string>('');
 
+  // 결제 준비용 API
   const { data: readyData, sendRequest: sendReady } =
     useAxios<ResponseFundingReady>({
       method: 'post',
@@ -30,6 +31,7 @@ const FundingPayment = () => {
       },
     });
 
+  // 결제 준비 성공 시 결제 승인용 API
   const { data: approveData, sendRequest: sendApprove } =
     useAxios<ResponseFundingSuccess>({
       method: 'post',

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import MessageCard from 'components/feature/MessageCard';
 import PaymentDetail from 'components/feature/PaymentDetail';
@@ -13,6 +13,7 @@ import { ResponseFundingReady, ResponseFundingSuccess } from 'types/payment';
 import styles from './index.module.scss';
 
 const FundingPayment = () => {
+  const navigate = useNavigate();
   const { state } = useLocation();
   const { fundingId }: { fundingId: number } = state;
 
@@ -57,7 +58,7 @@ const FundingPayment = () => {
     if (!approveData) return;
 
     console.log(approveData);
-    // approveData 들고 결제완료 페이지로 이동
+    navigate('/funding/complete', { state: approveData });
   }, [approveData]);
 
   return (

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -45,10 +45,19 @@ const FundingPayment = () => {
     await sendReady();
   };
 
-  // handle ready
+  // handle ready response
   useEffect(() => {
     if (!readyData) return;
-    sendApprove();
+
+    const { redirectUrl } = readyData;
+
+    if (redirectUrl.includes('/payments/success')) {
+      sendApprove();
+    } else if (redirectUrl.includes('/payments/fail')) {
+      navigate('/payment/fail');
+    } else if (redirectUrl.includes('/payments/cancel')) {
+      navigate('/payment/cancel');
+    }
   }, [readyData]);
 
   // handle success

--- a/src/pages/FundingPayment/index.tsx
+++ b/src/pages/FundingPayment/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import MessageCard from 'components/feature/MessageCard';
@@ -6,8 +6,11 @@ import PaymentDetail from 'components/feature/PaymentDetail';
 import MainWrapper from 'components/ui/MainWrapper';
 import FundingDetail from 'layouts/FundingPayment/FundingDetail';
 
-import styles from './index.module.scss';
+import { useAxios } from 'hooks/useAxios';
 
+import { ResponseFundingReady, ResponseFundingSuccess } from 'types/payment';
+
+import styles from './index.module.scss';
 
 const FundingPayment = () => {
   const { state } = useLocation();
@@ -15,9 +18,47 @@ const FundingPayment = () => {
 
   const [fundingAmount, setFundingAmount] = useState<number>(0);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const { data: readyData, sendRequest: sendReady } =
+    useAxios<ResponseFundingReady>({
+      method: 'post',
+      url: '/funding/payments/ready',
+      data: {
+        fundingId,
+        amount: fundingAmount,
+      },
+    });
+
+  const { data: approveData, sendRequest: sendApprove } =
+    useAxios<ResponseFundingSuccess>({
+      method: 'post',
+      url: '/funding/payments/success',
+      data: {
+        tid: readyData?.tid,
+        pgToken: '47aa61cf839cac18f669',
+        orderNumber: readyData?.orderNumber,
+      },
+    });
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    await sendReady();
   };
+
+  // handle ready
+  useEffect(() => {
+    if (!readyData) return;
+
+    console.log(readyData);
+    sendApprove();
+  }, [readyData]);
+
+  // handle success
+  useEffect(() => {
+    if (!approveData) return;
+
+    console.log(approveData);
+    // approveData 들고 결제완료 페이지로 이동
+  }, [approveData]);
 
   return (
     <MainWrapper>

--- a/src/pages/PaymentCancel/index.tsx
+++ b/src/pages/PaymentCancel/index.tsx
@@ -1,0 +1,5 @@
+const PaymentCancel = () => {
+  return <div>PaymentCancel</div>;
+};
+
+export default PaymentCancel;

--- a/src/pages/PaymentFail/index.tsx
+++ b/src/pages/PaymentFail/index.tsx
@@ -1,0 +1,5 @@
+const PaymentFail = () => {
+  return <div>PaymentFail</div>;
+};
+
+export default PaymentFail;

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,3 +1,5 @@
+import { ProductItem } from './productItem';
+
 export type RequestExpectedPaymentAmount = {
   productId: number;
   quantity: number;
@@ -20,4 +22,24 @@ export type ResponseFundingPreview = {
     goalAmount: number;
     remainAmount: number;
   };
+};
+
+export type RequestFundingReady = {
+  fundingId: number;
+  amount: number;
+};
+
+export type ResponseFundingReady = {
+  tid: string;
+  redirectUrl: string;
+  orderNumber: string;
+};
+
+export type ResponseFundingSuccess = {
+  receiver: {
+    name: string;
+    photoUrl: string;
+  };
+  product: Pick<ProductItem, 'brandName' | 'name' | 'photo'>;
+  attributeAmount: number;
 };

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -16,7 +16,7 @@ export type ResponseFundingPreview = {
   photo: string;
   optionNames: string[] | null;
   amount: {
-    totalAmount: number;
+    productAmount: number;
     goalAmount: number;
     remainAmount: number;
   };


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #238

## 📝작업 내용

- 펀딩 결제 준비 API 연동
- 펀딩 결제 승인 API 연동
- 결제 진행 중일 때 페이지를 조작할 수 없게 함
- 결제 금액이 0원인 경우 버튼을 클릭할 수 없도록 변경

## 🙏리뷰 요구사항

### 테스트
개발 환경에서는 잘 작동하긴 하는데... 실제로 잘 동작하는지 확인하기 위해 배포를 얼른 해야 할 것 같네욥

### 결제 시나리오
리뷰하실 때 결제 시나리오를 이해하고 보시면 더 편할 것 같아 간략히 적어봅니다. 아래는 결제 성공 시나리오입니다.
1. 결제 버튼 클릭 시 `결제 준비`를 요청한다. (=> 카카오페이 결제창 팝업)
2. 1의 응답으로 받은 정보를 바탕으로 `결제 승인`을 요청한다. (=>서버에서 결제 처리)
3. 2의 응답으로 받은 정보를 가지고 결제 완료 페이지로 이동한다.