### PR TITLE
Feat/242

### DIFF
--- a/src/components/ui/Tabs/index.module.scss
+++ b/src/components/ui/Tabs/index.module.scss
@@ -62,3 +62,22 @@
     }
   }
 }
+
+.funding_history {
+  .wrapper_tab {
+    width: 50%;
+    text-align: center;
+    padding: 14px 0;
+    line-height: 22px;
+    font-weight: 400;
+
+    &.on {
+      font-weight: 700;
+      border-bottom: 4px solid #000;
+
+      .txt_name {
+        color: #000;
+      }
+    }
+  }
+}

--- a/src/components/ui/Tabs/index.tsx
+++ b/src/components/ui/Tabs/index.tsx
@@ -8,7 +8,7 @@ import styles from './index.module.scss';
 type TabProps = {
   initialTabId: Tab['id'];
   tabs: Tab[];
-  mode: 'product_list' | 'product_detail';
+  mode: 'product_list' | 'product_detail' | 'funding_history';
 };
 
 const Tabs = ({ initialTabId = 0, tabs, mode }: TabProps) => {

--- a/src/pages/MyPage/FundingHistory/index.module.scss
+++ b/src/pages/MyPage/FundingHistory/index.module.scss
@@ -1,0 +1,9 @@
+@import 'styles/mixins.module';
+
+.title {
+  @include font(28px, 800);
+
+  margin: 40px 0 30px;
+  line-height: 38px;
+  white-space: pre-line;
+}

--- a/src/pages/MyPage/FundingHistory/index.tsx
+++ b/src/pages/MyPage/FundingHistory/index.tsx
@@ -1,5 +1,30 @@
+import Tabs from 'components/ui/Tabs';
+
+import { Tab } from 'types/tab';
+
+import styles from './index.module.scss';
+
+const userName = '보경';
 const FundingHistory = () => {
-  return <>펀딩내역</>;
+  const tabs: Tab[] = [
+    {
+      id: 0,
+      name: '내가 등록한 펀딩',
+      content: <>내가 등록한 펀딩</>,
+    },
+    {
+      id: 1,
+      name: '내가 기여한 펀딩',
+      content: <>내가 기여한 펀딩</>,
+    },
+  ];
+
+  return (
+    <>
+      <div className={styles.title}>{`${userName}님의 \n펀딩내역`}</div>
+      <Tabs initialTabId={0} mode="funding_history" tabs={tabs} />
+    </>
+  );
 };
 
 export default FundingHistory;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #242

## 📝작업 내용
- 펀딩내역 페이지 레이아웃 구현
![image](https://github.com/KakaoFunding/front-end/assets/79066587/d1a0f704-9c8c-4862-9404-e0b8ff2c223b)

## 🙏리뷰 요구사항(선택)
- 실제 펀딩내역 디자인이랑 조금 다르게 구현되었는데요 그 이유는 저번 주문내역 구현시 말씀드렸던 것 처럼 사이드바 outlet 요소에 스타일이 적용되어 있어 왼쪽의 여백을 없앨수 없기 때문이에요! 주문내역은 이미 다른 스타일로 구현을 하기로 했고 퍼딩내역도 일관성있게 구현하는 것이 좋을 것 같아 기존 디자인에서 스타일만 조금 바꿨습니다.
- 기능 구현에는 이상 없습니다
![image](https://github.com/KakaoFunding/front-end/assets/79066587/8a519f93-17d0-4b0b-863f-7b2865d90d29)

