### PR TITLE
Feat/256

### DIFF
--- a/src/components/feature/ProductItem/ColumnProductItem/index.tsx
+++ b/src/components/feature/ProductItem/ColumnProductItem/index.tsx
@@ -28,7 +28,11 @@ const ColumnProductItem = ({ product, size }: ColumnProductItemProps) => {
       </Link>
       <div className={styles.wrapper_util_info}>
         <CartButton />
-        <WishButton isWished={product.wished} wishCount={product.wishCount} />
+        <WishButton
+          productId={product.productId}
+          isWished={product.wished}
+          wishCount={product.wishCount}
+        />
       </div>
     </article>
   );

--- a/src/components/feature/ProductItem/WishButton/index.tsx
+++ b/src/components/feature/ProductItem/WishButton/index.tsx
@@ -3,6 +3,7 @@ import { MouseEvent, useEffect, useState } from 'react';
 
 import WishModal from 'components/ui/Modal/WishModal';
 
+import { useLogin } from 'hooks/useLogin';
 import { useModal } from 'hooks/useModal';
 import { useDeleteWish } from 'hooks/useWish';
 import { formatNumberWithComma } from 'utils/format';
@@ -23,6 +24,7 @@ const WishButton = ({
   isWished: isWishedProp,
   wishCount: wishCountProp,
 }: WishButtonProps) => {
+  const { isLoggedIn, login, confirmLogin } = useLogin();
   const { isOpen, open, close, scrollPos } = useModal();
   const { deleteWishData, deleteWish } = useDeleteWish(productId);
   const [wishCount, setWishCount] = useState<number>(wishCountProp);
@@ -37,8 +39,13 @@ const WishButton = ({
 
   const handleClickWish = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (wished) deleteWish();
-    else open();
+    if (isLoggedIn) {
+      if (wished) deleteWish();
+      else open();
+    } else {
+      const result = confirmLogin();
+      if (result) login();
+    }
   };
 
   const handleWishAdded = (wishData: ResponseWishAddOrDelete) => {

--- a/src/components/feature/ProductItem/WishButton/index.tsx
+++ b/src/components/feature/ProductItem/WishButton/index.tsx
@@ -13,18 +13,20 @@ type WishButtonProps = {
 };
 
 const WishButton = ({ isWished, wishCount }: WishButtonProps) => {
-  const DIVIDER = 10000;
-  const REMAINS = '만+';
 
   // TODO : API 요청
   const handleAddWish = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
   };
 
-  const formattedWishCount =
-    wishCount >= DIVIDER
-      ? Math.floor(wishCount / DIVIDER).toString() + REMAINS
-      : formatNumberWithComma(wishCount);
+  const formatWishCount = (count: number) => {
+    const DIVIDER = 10000;
+    const REMAINS = '만+';
+
+    return count >= DIVIDER
+      ? Math.floor(count / DIVIDER).toString() + REMAINS
+      : formatNumberWithComma(count);
+  };
 
   return (
     <button type="button" onClick={handleAddWish}>
@@ -35,7 +37,7 @@ const WishButton = ({ isWished, wishCount }: WishButtonProps) => {
       >
         {isWished ? '위시 해제' : '위시리스트 추가'}
       </span>
-      <span className={styles.txt_wish_cnt}>{formattedWishCount}</span>
+      <span className={styles.txt_wish_cnt}>{formatWishCount(wishCount)}</span>
     </button>
   );
 };

--- a/src/components/feature/ProductItem/WishButton/index.tsx
+++ b/src/components/feature/ProductItem/WishButton/index.tsx
@@ -8,6 +8,7 @@ import { useDeleteWish } from 'hooks/useWish';
 import { formatNumberWithComma } from 'utils/format';
 
 import { ProductItem } from 'types/productItem';
+import { ResponseWishAddOrDelete } from 'types/wish';
 
 import styles from './index.module.scss';
 
@@ -17,15 +18,19 @@ type WishButtonProps = {
   wishCount: ProductItem['wishCount'];
 };
 
-const WishButton = ({ productId, isWished, wishCount }: WishButtonProps) => {
+const WishButton = ({
+  productId,
+  isWished: isWishedProp,
+  wishCount: wishCountProp,
+}: WishButtonProps) => {
   const { isOpen, open, close, scrollPos } = useModal();
   const { deleteWishData, deleteWish } = useDeleteWish(productId);
-  const [count, setCount] = useState<number>(wishCount);
-  const [wished, setWished] = useState<boolean>(isWished);
+  const [wishCount, setWishCount] = useState<number>(wishCountProp);
+  const [wished, setWished] = useState<boolean>(isWishedProp);
 
   useEffect(() => {
     if (deleteWishData) {
-      setCount(deleteWishData.wishCount);
+      setWishCount(deleteWishData.wishCount);
       setWished(false);
     }
   }, [deleteWishData]);
@@ -36,8 +41,9 @@ const WishButton = ({ productId, isWished, wishCount }: WishButtonProps) => {
     else open();
   };
 
-  const handleWishAdded = () => {
+  const handleWishAdded = (wishData: ResponseWishAddOrDelete) => {
     setWished(true);
+    setWishCount(wishData.wishCount);
   };
 
   const formatWishCount = (num: number) => {
@@ -66,7 +72,9 @@ const WishButton = ({ productId, isWished, wishCount }: WishButtonProps) => {
         >
           {wished ? '위시 해제' : '위시리스트 추가'}
         </span>
-        <span className={styles.txt_wish_cnt}>{formatWishCount(count)}</span>
+        <span className={styles.txt_wish_cnt}>
+          {formatWishCount(wishCount)}
+        </span>
       </button>
     </>
   );

--- a/src/components/feature/ProductItem/WishButton/index.tsx
+++ b/src/components/feature/ProductItem/WishButton/index.tsx
@@ -1,6 +1,10 @@
 import clsx from 'clsx';
-import { MouseEvent } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
 
+import WishModal from 'components/ui/Modal/WishModal';
+
+import { useModal } from 'hooks/useModal';
+import { useDeleteWish } from 'hooks/useWish';
 import { formatNumberWithComma } from 'utils/format';
 
 import { ProductItem } from 'types/productItem';
@@ -8,37 +12,63 @@ import { ProductItem } from 'types/productItem';
 import styles from './index.module.scss';
 
 type WishButtonProps = {
+  productId: ProductItem['productId'];
   isWished: ProductItem['wished'];
   wishCount: ProductItem['wishCount'];
 };
 
-const WishButton = ({ isWished, wishCount }: WishButtonProps) => {
+const WishButton = ({ productId, isWished, wishCount }: WishButtonProps) => {
+  const { isOpen, open, close, scrollPos } = useModal();
+  const { deleteWishData, deleteWish } = useDeleteWish(productId);
+  const [count, setCount] = useState<number>(wishCount);
+  const [wished, setWished] = useState<boolean>(isWished);
 
-  // TODO : API 요청
-  const handleAddWish = (e: MouseEvent<HTMLButtonElement>) => {
+  useEffect(() => {
+    if (deleteWishData) {
+      setCount(deleteWishData.wishCount);
+      setWished(false);
+    }
+  }, [deleteWishData]);
+
+  const handleClickWish = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+    if (wished) deleteWish();
+    else open();
   };
 
-  const formatWishCount = (count: number) => {
+  const handleWishAdded = () => {
+    setWished(true);
+  };
+
+  const formatWishCount = (num: number) => {
     const DIVIDER = 10000;
     const REMAINS = '만+';
 
-    return count >= DIVIDER
-      ? Math.floor(count / DIVIDER).toString() + REMAINS
-      : formatNumberWithComma(count);
+    return num >= DIVIDER
+      ? Math.floor(num / DIVIDER).toString() + REMAINS
+      : formatNumberWithComma(num);
   };
 
   return (
-    <button type="button" onClick={handleAddWish}>
-      <span
-        className={clsx(styles.ico_wish, {
-          [styles.on]: isWished,
-        })}
-      >
-        {isWished ? '위시 해제' : '위시리스트 추가'}
-      </span>
-      <span className={styles.txt_wish_cnt}>{formatWishCount(wishCount)}</span>
-    </button>
+    <>
+      <WishModal
+        productId={productId}
+        isOpen={isOpen}
+        close={close}
+        scrollPos={scrollPos}
+        onWishAdded={handleWishAdded}
+      />
+      <button type="button" onClick={handleClickWish}>
+        <span
+          className={clsx(styles.ico_wish, {
+            [styles.on]: wished,
+          })}
+        >
+          {wished ? '위시 해제' : '위시리스트 추가'}
+        </span>
+        <span className={styles.txt_wish_cnt}>{formatWishCount(count)}</span>
+      </button>
+    </>
   );
 };
 

--- a/src/components/ui/Modal/WishModal/index.tsx
+++ b/src/components/ui/Modal/WishModal/index.tsx
@@ -26,7 +26,13 @@ const WISH_RADIO_INFO = [
 
 type WishRadioType = (typeof WISH_RADIO_STATUS)[keyof typeof WISH_RADIO_STATUS];
 
-const WishModal = ({ close, isOpen, scrollPos, productId }: WishModalProps) => {
+const WishModal = ({
+  close,
+  isOpen,
+  scrollPos,
+  productId,
+  onWishAdded = () => null,
+}: WishModalProps) => {
   const [radioStatus, setRadioStatus] = useState<WishRadioType>(
     WISH_RADIO_STATUS.OTHERS as WishRadioType,
   );
@@ -43,6 +49,7 @@ const WishModal = ({ close, isOpen, scrollPos, productId }: WishModalProps) => {
   const handleAddWish = async () => {
     await sendRequest();
     close();
+    onWishAdded();
   };
 
   useEffect(() => {

--- a/src/components/ui/Modal/WishModal/index.tsx
+++ b/src/components/ui/Modal/WishModal/index.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { Button } from 'components/ui/Button';
 import Modal from 'components/ui/Modal';
 
-import { useAxios } from 'hooks/useAxios';
+import { useAddWish } from 'hooks/useWish';
 
 import { WishModalProps } from 'types/modal';
 
@@ -36,18 +36,14 @@ const WishModal = ({
   const [radioStatus, setRadioStatus] = useState<WishRadioType>(
     WISH_RADIO_STATUS.OTHERS as WishRadioType,
   );
+  const { addWish } = useAddWish(productId, radioStatus);
 
   const handleRadioChange = (selectedRadio: WishRadioType) => {
     setRadioStatus(selectedRadio);
   };
 
-  const { sendRequest } = useAxios<{ id: number }>({
-    method: 'post',
-    url: `/products/${productId}/wishes?type=${radioStatus}`,
-  });
-
   const handleAddWish = async () => {
-    await sendRequest();
+    await addWish();
     close();
     onWishAdded();
   };

--- a/src/components/ui/Modal/WishModal/index.tsx
+++ b/src/components/ui/Modal/WishModal/index.tsx
@@ -45,8 +45,11 @@ const WishModal = ({
   const handleAddWish = async () => {
     await addWish();
     close();
-    if (addWishData) onWishAdded(addWishData);
   };
+
+  useEffect(() => {
+    if (addWishData) onWishAdded(addWishData);
+  }, [addWishData]);
 
   useEffect(() => {
     setRadioStatus(WISH_RADIO_STATUS.OTHERS as WishRadioType);

--- a/src/components/ui/Modal/WishModal/index.tsx
+++ b/src/components/ui/Modal/WishModal/index.tsx
@@ -36,7 +36,7 @@ const WishModal = ({
   const [radioStatus, setRadioStatus] = useState<WishRadioType>(
     WISH_RADIO_STATUS.OTHERS as WishRadioType,
   );
-  const { addWish } = useAddWish(productId, radioStatus);
+  const { addWishData, addWish } = useAddWish(productId, radioStatus);
 
   const handleRadioChange = (selectedRadio: WishRadioType) => {
     setRadioStatus(selectedRadio);
@@ -45,7 +45,7 @@ const WishModal = ({
   const handleAddWish = async () => {
     await addWish();
     close();
-    onWishAdded();
+    if (addWishData) onWishAdded(addWishData);
   };
 
   useEffect(() => {

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -4,11 +4,11 @@ import { useUserExists } from './useUserExists';
 
 export const useLogin = () => {
   const isLoggedIn = useUserExists(); // 로그인 여부
+  const { pathname, search } = useLocation();
 
   const login = () => {
-    if (!isLoggedIn) return;
+    if (isLoggedIn) return;
 
-    const { pathname, search } = useLocation();
     const currentUrl = pathname + search;
     const REST_API_KEY = import.meta.env.VITE_REST_API_KEY;
     const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URL;

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,28 @@
+import { useLocation } from 'react-router-dom';
+
+import { useUserExists } from './useUserExists';
+
+export const useLogin = () => {
+  const isLoggedIn = useUserExists(); // 로그인 여부
+
+  const login = () => {
+    if (!isLoggedIn) return;
+
+    const { pathname, search } = useLocation();
+    const currentUrl = pathname + search;
+    const REST_API_KEY = import.meta.env.VITE_REST_API_KEY;
+    const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URL;
+    const KAKAO_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&state=${currentUrl}&scope=friends`;
+
+    window.location.href = KAKAO_URL;
+  };
+
+  const confirmLogin = () => {
+    const message = '로그인 후 이용하실 수 있습니다.\n로그인하시겠습니까?';
+    const result = window.confirm(message);
+
+    return result;
+  };
+
+  return { isLoggedIn, login, confirmLogin };
+};

--- a/src/hooks/useUserExists.ts
+++ b/src/hooks/useUserExists.ts
@@ -3,10 +3,10 @@ import { useUserStore } from 'store/useUserStore';
 import { getSessionStorageItem } from 'utils/sessionStorage';
 
 export const useUserExists = (): boolean => {
-  const name = useUserStore((state) => state.name);
+  const providerId = useUserStore((state) => state.providerId);
   const accessToken = getSessionStorageItem('accessToken');
 
-  if (name && accessToken) return true;
+  if (providerId && accessToken) return true;
 
   return false;
 };

--- a/src/hooks/useWish.ts
+++ b/src/hooks/useWish.ts
@@ -1,30 +1,27 @@
 import { ProductItem } from 'types/productItem';
+import { ResponseWishAddOrDelete } from 'types/wish';
 
 import { useAxios } from './useAxios';
 
-type ResponseType = {
-  productId: number;
-  wishCount: number;
-};
-
 export const useAddWish = (
   productId: ProductItem['productId'],
-  isPublic: boolean,
+  type: string,
 ) => {
-  const { data: addWishData, sendRequest: addWish } = useAxios<ResponseType>({
-    method: 'post',
-    url: `/products/${productId}/wishes`,
-    params: {
-      type: isPublic ? 'OTHERS' : 'ME',
-    },
-  });
+  const { data: addWishData, sendRequest: addWish } =
+    useAxios<ResponseWishAddOrDelete>({
+      method: 'post',
+      url: `/products/${productId}/wishes`,
+      params: {
+        type,
+      },
+    });
 
   return { addWishData, addWish };
 };
 
 export const useDeleteWish = (productId: ProductItem['productId']) => {
   const { data: deleteWishData, sendRequest: deleteWish } =
-    useAxios<ResponseType>({
+    useAxios<ResponseWishAddOrDelete>({
       method: 'delete',
       url: `/products/${productId}/wishes`,
     });

--- a/src/hooks/useWish.ts
+++ b/src/hooks/useWish.ts
@@ -1,0 +1,33 @@
+import { ProductItem } from 'types/productItem';
+
+import { useAxios } from './useAxios';
+
+type ResponseType = {
+  productId: number;
+  wishCount: number;
+};
+
+export const useAddWish = (
+  productId: ProductItem['productId'],
+  isPublic: boolean,
+) => {
+  const { data: addWishData, sendRequest: addWish } = useAxios<ResponseType>({
+    method: 'post',
+    url: `/products/${productId}/wishes`,
+    params: {
+      type: isPublic ? 'OTHERS' : 'ME',
+    },
+  });
+
+  return { addWishData, addWish };
+};
+
+export const useDeleteWish = (productId: ProductItem['productId']) => {
+  const { data: deleteWishData, sendRequest: deleteWish } =
+    useAxios<ResponseType>({
+      method: 'delete',
+      url: `/products/${productId}/wishes`,
+    });
+
+  return { deleteWishData, deleteWish };
+};

--- a/src/layouts/App/Header/LogoutModal/index.tsx
+++ b/src/layouts/App/Header/LogoutModal/index.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useNavigate } from 'react-router-dom';
 
 import { useUserStore } from 'store/useUserStore';
 
@@ -20,6 +21,8 @@ type LogoutModalProps = {
 };
 
 const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
+  const navigate = useNavigate();
+
   const clearUser = useUserStore((state) => state.clearUserInfo);
   const accessToken = getSessionStorageItem('accessToken');
   const refreshToken = getLocalStorageItem('refreshToken');
@@ -30,6 +33,8 @@ const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
     clearUser();
     clearSessionStorageItem();
     clearLocalStorageItem('refreshToken');
+
+    navigate('/');
   };
 
   return (

--- a/src/layouts/App/Header/SocialKakaoLogin/index.tsx
+++ b/src/layouts/App/Header/SocialKakaoLogin/index.tsx
@@ -1,38 +1,28 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 
 import { useUserStore } from 'store/useUserStore';
 
-import { useUserExists } from 'hooks/useUserExists';
+import { useLogin } from 'hooks/useLogin';
 
 import LogoutModal from '../LogoutModal';
 
 import styles from './index.module.scss';
 
 const SocialKakaoLogin = () => {
-  const { pathname, search } = useLocation();
-  const isUserExists = useUserExists();
-  const currentUrl = pathname + search;
-  const REST_API_KEY = import.meta.env.VITE_REST_API_KEY;
-  const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URL;
-  const KAKAO_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&state=${currentUrl}&scope=friends`;
+  const { isLoggedIn, login } = useLogin();
   const userName = useUserStore().name;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleLogin = () => {
-    window.location.href = KAKAO_URL;
-  };
-
   const handleAuthAction = () => {
-    if (isUserExists) {
+    if (isLoggedIn) {
       setIsModalOpen(!isModalOpen);
     } else {
-      handleLogin();
+      login();
     }
   };
 
-  const buttonText = isUserExists ? (
+  const buttonText = isLoggedIn ? (
     <>
       <span>{userName}</span>
       <span className={styles.ico_logout}>모달 버튼</span>
@@ -50,7 +40,7 @@ const SocialKakaoLogin = () => {
       >
         {buttonText}
       </button>
-      <LogoutModal modalState={isModalOpen} userState={isUserExists} />
+      <LogoutModal modalState={isModalOpen} userState={isLoggedIn} />
     </>
   );
 };

--- a/src/layouts/Home/Receiver/FriendWish/FriendWishItem/index.tsx
+++ b/src/layouts/Home/Receiver/FriendWish/FriendWishItem/index.tsx
@@ -30,6 +30,7 @@ const FriendWishItem = ({ product }: { product: ProductItem }) => {
             <div className={styles.wrapper_btn}>
               <CartButton />
               <WishButton
+                productId={product.productId}
                 isWished={product.wished}
                 wishCount={product.wishCount}
               />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,6 +34,7 @@ import PaymentFail from 'pages/PaymentFail';
 import Product from 'pages/Product';
 import Search from 'pages/Search';
 import SearchResult from 'pages/SearchResult';
+import UnPrivateRoute from 'pages/UnPrivateRoute';
 
 // eslint-disable-next-line consistent-return
 const enableMocking = async () => {
@@ -60,6 +61,10 @@ const router = createBrowserRouter([
     children: [
       { path: '/', element: <Home /> },
       { path: '/home', element: <Home /> },
+      {
+        element: <UnPrivateRoute />,
+        children: [{ path: '/auth', element: <Auth /> }],
+      },
       {
         path: '/mypage',
         element: <Navigate to="/mypage/giftbox" />,
@@ -143,7 +148,6 @@ const router = createBrowserRouter([
         path: '/payment/cancel',
         element: <PaymentCancel />,
       },
-      { path: '/auth', element: <Auth /> },
       {
         path: '/cart',
         element: <Cart />,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,6 +31,7 @@ import Wish from 'pages/MyPage/Wish';
 import NotFound from 'pages/NotFound';
 import PaymentCancel from 'pages/PaymentCancel';
 import PaymentFail from 'pages/PaymentFail';
+import PrivateRoute from 'pages/PrivateRoute';
 import Product from 'pages/Product';
 import Search from 'pages/Search';
 import SearchResult from 'pages/SearchResult';
@@ -66,37 +67,70 @@ const router = createBrowserRouter([
         children: [{ path: '/auth', element: <Auth /> }],
       },
       {
-        path: '/mypage',
-        element: <Navigate to="/mypage/giftbox" />,
-      },
-      {
-        path: '/mypage',
-        element: <MyPage />,
+        element: <PrivateRoute />,
         children: [
           {
-            path: 'giftbox',
-            element: <GiftBox />,
+            path: '/cart',
+            element: <Cart />,
           },
           {
-            path: 'fundingbox',
-            element: <FundingBox />,
+            path: '/mypage',
+            element: <Navigate to="/mypage/giftbox" />,
           },
+          {
+            path: '/mypage',
+            element: <MyPage />,
+            children: [
+              {
+                path: 'giftbox',
+                element: <GiftBox />,
+              },
+              {
+                path: 'fundingbox',
+                element: <FundingBox />,
+              },
 
-          {
-            path: 'wish',
-            element: <Wish />,
+              {
+                path: 'wish',
+                element: <Wish />,
+              },
+              {
+                path: 'funding',
+                element: <Funding />,
+              },
+              {
+                path: 'orderHistory',
+                element: <OrderHistory />,
+              },
+              {
+                path: 'fundingHistory',
+                element: <FundingHistory />,
+              },
+            ],
           },
           {
-            path: 'funding',
-            element: <Funding />,
+            path: '/bill/gift',
+            element: <GiftPayment />,
           },
           {
-            path: 'orderHistory',
-            element: <OrderHistory />,
+            path: '/bill/funding',
+            element: <FundingPayment />,
           },
           {
-            path: 'fundingHistory',
-            element: <FundingHistory />,
+            path: '/gift/complete',
+            element: <GiftComplete />,
+          },
+          {
+            path: '/funding/complete',
+            element: <FundingComplete />,
+          },
+          {
+            path: '/payment/fail',
+            element: <PaymentFail />,
+          },
+          {
+            path: '/payment/cancel',
+            element: <PaymentCancel />,
           },
         ],
       },
@@ -123,34 +157,6 @@ const router = createBrowserRouter([
       {
         path: '/search/result',
         element: <SearchResult />,
-      },
-      {
-        path: '/bill/gift',
-        element: <GiftPayment />,
-      },
-      {
-        path: '/bill/funding',
-        element: <FundingPayment />,
-      },
-      {
-        path: '/gift/complete',
-        element: <GiftComplete />,
-      },
-      {
-        path: '/funding/complete',
-        element: <FundingComplete />,
-      },
-      {
-        path: '/payment/fail',
-        element: <PaymentFail />,
-      },
-      {
-        path: '/payment/cancel',
-        element: <PaymentCancel />,
-      },
-      {
-        path: '/cart',
-        element: <Cart />,
       },
     ],
   },

--- a/src/pages/PrivateRoute/index.tsx
+++ b/src/pages/PrivateRoute/index.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+
+import { useLogin } from 'hooks/useLogin';
+import { useUserExists } from 'hooks/useUserExists';
+
+const PrivateRoute = () => {
+  const isUserLoggedIn = useUserExists();
+
+  if (isUserLoggedIn) {
+    return <Outlet />;
+  }
+
+  const navigate = useNavigate();
+  const { login, confirmLogin } = useLogin();
+  const result = confirmLogin();
+
+  useEffect(() => {
+    if (result) login();
+    else navigate(-1);
+  }, [result]);
+
+  return null;
+};
+
+export default PrivateRoute;

--- a/src/pages/UnPrivateRoute/index.tsx
+++ b/src/pages/UnPrivateRoute/index.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useUserExists } from 'hooks/useUserExists';
+
+const UnPrivateRoute = () => {
+  const isUserLoggedIn = useUserExists();
+
+  return isUserLoggedIn ? <Navigate to="/" /> : <Outlet />;
+};
+
+export default UnPrivateRoute;

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -14,5 +14,7 @@ export type FundingModalProps = ModalProps &
     productThumbnail: string;
   };
 
-export type WishModalProps = ModalProps &
-  Pick<ProductDescriptionResponse, 'productId'>;
+export type WishModalProps = ModalProps & {
+  productId: number;
+  onWishAdded?: () => void;
+};

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,4 +1,5 @@
 import { OptionDetail, ProductDescriptionResponse } from './product';
+import { ResponseWishAddOrDelete } from './wish';
 
 type ModalProps = {
   close: () => void;
@@ -16,5 +17,5 @@ export type FundingModalProps = ModalProps &
 
 export type WishModalProps = ModalProps & {
   productId: number;
-  onWishAdded?: () => void;
+  onWishAdded?: (addWishData: ResponseWishAddOrDelete) => void;
 };

--- a/src/types/wish.ts
+++ b/src/types/wish.ts
@@ -7,3 +7,8 @@ export type WishItemType = {
 };
 
 export type WishResponse = WishItemType[];
+
+export type ResponseWishAddOrDelete = {
+  productId: number;
+  wishCount: number;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #256

## 📝작업 내용
![image](https://github.com/KakaoFunding/front-end/assets/82873315/21703177-b2a2-4e83-b13b-4d8bc4fb1190)

- 위시 버튼 클릭 핸들러 추가
  - 위시 버튼 클릭 시 로그인 여부에 따라 로그인 또는 위시등록/취소 처리
  - 위시 등록 API 연동
  - 위시 취소 API 연동
  - 위시 모달에 "onWishAdded" prop 추가 (위시 등록 시 할 액션을 콜백함수로 받는 것)
  - 위시 등록/취소 응답으로 온 위시 수를 즉각 반영

## 🙏리뷰 요구사항

- 상품 상세 조회 페이지 내 위시 버튼도 하려다가 보경님께서 하고 계신 거 같아서 놔두었습니다. 또 이 버튼 구현하려면 `상품상세 조회(상세설명)` API에 `위시 여부`와 `위시 수`가 추가되어야 하는데, 그 부분은 태환님께 말씀드렸습니다. 태환님께서 내일 작업하신다고 하셨습니다.