### PR TITLE
유저 타입 변경, Home/Receiver 컴포넌트 실제 데이터 연동

### DIFF
--- a/src/layouts/Home/Receiver/index.tsx
+++ b/src/layouts/Home/Receiver/index.tsx
@@ -4,7 +4,7 @@ import MainWrapper from 'components/ui/MainWrapper';
 import { useSelectedFriendsStore } from 'store/useSelectedFriendsStore';
 import { useUserStore } from 'store/useUserStore';
 
-import { useUserExists } from 'hooks/useUserExists';
+import { useLogin } from 'hooks/useLogin';
 import { getSessionStorageItem } from 'utils/sessionStorage';
 
 import FriendFunding from './FriendFunding';
@@ -39,8 +39,8 @@ const Receiver = () => {
   const clearFriendsList = useSelectedFriendsStore(
     (state) => state.clearSelectedFriends,
   );
-  const isLogin = useUserExists();
-  const PROFILE_IMAGE = isLogin && isSelfSelected ? profileUrl : getImgUrl();
+  const { isLoggedIn } = useLogin();
+  const PROFILE_IMAGE = isLoggedIn && isSelfSelected ? profileUrl : getImgUrl();
   const isKakaoConnected = window.Kakao?.isInitialized();
 
   // 서버 복구되면 테스트 해봐야함
@@ -101,7 +101,7 @@ const Receiver = () => {
               onClick={handleClick}
             />
             <strong className={styles.title_selector}>
-              {isLogin && !isSelected && (
+              {isLoggedIn && !isSelected && (
                 <>
                   {`${name}님`}
                   <br />

--- a/src/layouts/Home/Receiver/index.tsx
+++ b/src/layouts/Home/Receiver/index.tsx
@@ -4,18 +4,13 @@ import MainWrapper from 'components/ui/MainWrapper';
 import { useSelectedFriendsStore } from 'store/useSelectedFriendsStore';
 import { useUserStore } from 'store/useUserStore';
 
+import { useUserExists } from 'hooks/useUserExists';
 import { getSessionStorageItem } from 'utils/sessionStorage';
 
 import FriendFunding from './FriendFunding';
 import FriendWish from './FriendWish';
 
 import styles from './index.module.scss';
-
-const mockdata = {
-  login: false,
-  name: '보경',
-  myProfileImgUrl: '',
-};
 
 type PickerResponseTypes = {
   users: [];
@@ -40,12 +35,12 @@ const Receiver = () => {
     getImgUrl,
   } = useSelectedFriendsStore();
   const socialAccessToken = getSessionStorageItem('socialToken');
-  const { name, providerId } = useUserStore();
+  const { name, providerId, profileUrl } = useUserStore();
   const clearFriendsList = useSelectedFriendsStore(
     (state) => state.clearSelectedFriends,
   );
-  const PROFILE_IMAGE =
-    mockdata.login && isSelfSelected ? mockdata.myProfileImgUrl : getImgUrl();
+  const isLogin = useUserExists();
+  const PROFILE_IMAGE = isLogin && isSelfSelected ? profileUrl : getImgUrl();
   const isKakaoConnected = window.Kakao?.isInitialized();
 
   // 서버 복구되면 테스트 해봐야함
@@ -106,9 +101,9 @@ const Receiver = () => {
               onClick={handleClick}
             />
             <strong className={styles.title_selector}>
-              {mockdata.login && !isSelected && (
+              {isLogin && !isSelected && (
                 <>
-                  {`${mockdata.name}님`}
+                  {`${name}님`}
                   <br />
                 </>
               )}

--- a/src/layouts/Home/Receiver/index.tsx
+++ b/src/layouts/Home/Receiver/index.tsx
@@ -43,7 +43,6 @@ const Receiver = () => {
   const PROFILE_IMAGE = isLoggedIn && isSelfSelected ? profileUrl : getImgUrl();
   const isKakaoConnected = window.Kakao?.isInitialized();
 
-  // 서버 복구되면 테스트 해봐야함
   const getTitle = () => {
     let title = '';
 

--- a/src/layouts/Home/Receiver/index.tsx
+++ b/src/layouts/Home/Receiver/index.tsx
@@ -39,7 +39,7 @@ const Receiver = () => {
   const clearFriendsList = useSelectedFriendsStore(
     (state) => state.clearSelectedFriends,
   );
-  const { isLoggedIn } = useLogin();
+  const { isLoggedIn, login, confirmLogin } = useLogin();
   const PROFILE_IMAGE = isLoggedIn && isSelfSelected ? profileUrl : getImgUrl();
   const isKakaoConnected = window.Kakao?.isInitialized();
 
@@ -63,6 +63,13 @@ const Receiver = () => {
   }
 
   const handleClick = () => {
+    if (!isLoggedIn) {
+      const result = confirmLogin();
+
+      if (result) login();
+      return;
+    }
+
     window.Kakao?.Picker.selectFriends({
       title: '친구 선택',
       enableSearch: true,

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -11,10 +11,10 @@ type UserState = {
 export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
-      name: null,
-      profileUrl: null,
-      providerId: null,
-      birthDate: null,
+      name: '',
+      profileUrl: '',
+      providerId: '',
+      birthDate: '',
       setUserInfo: ({ name, profileUrl, providerId, birthDate }) =>
         set({
           name,
@@ -24,10 +24,10 @@ export const useUserStore = create<UserState>()(
         }),
       clearUserInfo: () =>
         set({
-          name: null,
-          profileUrl: null,
-          providerId: null,
-          birthDate: null,
+          name: '',
+          profileUrl: '',
+          providerId: '',
+          birthDate: '',
         }),
     }),
     {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,8 +1,8 @@
 export type User = {
-  name: string | null;
-  profileUrl: string | null;
-  providerId: string | null;
-  birthDate: string | null;
+  name: string;
+  profileUrl: string;
+  providerId: string;
+  birthDate: string;
 };
 
 export type UserWithUserId = User & {


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #291 

## 📝작업 내용

<img width="447" alt="image" src="https://github.com/KakaoFunding/front-end/assets/123801385/84a46a58-3755-4fe5-9f42-a9e52e09e20d">

- 사진에 유저의 이름이 나오고 있는 부분이 `mockData`로 되어 있었는데 실제 데이터를 연동.
- 유저 타입에 `null`을 모두 제거.
