### PR TITLE
Fix/300 피커 버그 수정

### DIFF
--- a/src/layouts/App/Header/LogoutModal/index.tsx
+++ b/src/layouts/App/Header/LogoutModal/index.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 
+import { useSelectedFriendsStore } from 'store/useSelectedFriendsStore';
 import { useUserStore } from 'store/useUserStore';
 
 import {
@@ -24,6 +25,9 @@ const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
   const navigate = useNavigate();
 
   const clearUser = useUserStore((state) => state.clearUserInfo);
+  const clearSelectedFiends = useSelectedFriendsStore(
+    (state) => state.clearSelectedFriends,
+  );
   const accessToken = getSessionStorageItem('accessToken');
   const refreshToken = getLocalStorageItem('refreshToken');
 
@@ -31,6 +35,7 @@ const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
     await logout({ accessToken, refreshToken });
 
     clearUser();
+    clearSelectedFiends();
     clearSessionStorageItem();
     clearLocalStorageItem('refreshToken');
 

--- a/src/services/api/v1/index.ts
+++ b/src/services/api/v1/index.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import { useSelectedFriendsStore } from 'store/useSelectedFriendsStore';
 import { useUserStore } from 'store/useUserStore';
 
 import {
@@ -68,6 +69,7 @@ apiV1.interceptors.response.use(
 
       if (response.status === 404) {
         useUserStore.getState().clearUserInfo();
+        useSelectedFriendsStore.getState().clearSelectedFriends();
         clearSessionStorageItem();
         clearLocalStorageItem('refreshToken');
         window.location.replace('/');

--- a/src/store/useSelectedFriendsStore.ts
+++ b/src/store/useSelectedFriendsStore.ts
@@ -5,7 +5,10 @@ import { PickerResponseData, User } from 'types/user';
 
 const defaultImgUrl =
   'https://github.com/KakaoFunding/front-end/blob/dev/src/assets/bg_profile_default.png?raw=true';
-const peopleImgUrl = 'src/assets/profile_people.png';
+const peopleImgUrl =
+  'https://github.com/KakaoFunding/front-end/blob/dev/src/assets/profile_people.png?raw=true';
+const friendsDefaultImgUrl =
+  'https://github.com/KakaoFunding/front-end/blob/dev/src/assets/profile_default.png?raw=true';
 
 type SelectedFriendsState = {
   isSelected: boolean;
@@ -55,9 +58,20 @@ export const useSelectedFriendsStore = create<
         }),
 
       getImgUrl: () => {
-        if (get().selectedHeadCount > 1) return peopleImgUrl;
-        if (get().selectedHeadCount === 1)
-          return get().selectedFriends[0].profile_thumbnail_image!;
+        const selectCount = get().selectedHeadCount;
+
+        if (selectCount > 1) return peopleImgUrl;
+        if (selectCount === 1) {
+          const friendsProfileImgUrl =
+            get().selectedFriends[0].profile_thumbnail_image;
+
+          if (!friendsProfileImgUrl) {
+            return friendsDefaultImgUrl;
+          }
+
+          return friendsProfileImgUrl;
+        }
+
         return defaultImgUrl;
       },
     }),

--- a/src/store/useSelectedFriendsStore.ts
+++ b/src/store/useSelectedFriendsStore.ts
@@ -3,9 +3,9 @@ import { persist } from 'zustand/middleware';
 
 import { PickerResponseData, User } from 'types/user';
 
-const defaultImgUrl = 'assets/bg_profile_default.png';
-const peopleImgUrl = 'assets/profile_people.png';
-const friendsDefaultImgUrl = 'assets/profile_default.png';
+import defaultImgUrl from 'assets/bg_profile_default.png';
+import friendsDefaultImgUrl from 'assets/profile_default.png';
+import peopleImgUrl from 'assets/profile_people.png';
 
 type SelectedFriendsState = {
   isSelected: boolean;

--- a/src/store/useSelectedFriendsStore.ts
+++ b/src/store/useSelectedFriendsStore.ts
@@ -3,12 +3,9 @@ import { persist } from 'zustand/middleware';
 
 import { PickerResponseData, User } from 'types/user';
 
-const defaultImgUrl =
-  'https://github.com/KakaoFunding/front-end/blob/dev/src/assets/bg_profile_default.png?raw=true';
-const peopleImgUrl =
-  'https://github.com/KakaoFunding/front-end/blob/dev/src/assets/profile_people.png?raw=true';
-const friendsDefaultImgUrl =
-  'https://github.com/KakaoFunding/front-end/blob/dev/src/assets/profile_default.png?raw=true';
+const defaultImgUrl = 'assets/bg_profile_default.png';
+const peopleImgUrl = 'assets/profile_people.png';
+const friendsDefaultImgUrl = 'assets/profile_default.png';
 
 type SelectedFriendsState = {
   isSelected: boolean;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #300 

## 📝작업 내용

- 친구가 기본 프로필일 경우 피커에서 리스폰스로 `null`을 전달해주면서 이미지가 표시되지 않는 문제 수정
- 여러명을 선택했을 때 띄워지는 이미지가 깨지는 문제 수정
- 로그아웃, `reissue` `404 response` 에서 선택한 친구를 초기화하는 로직 추가

## 🙏리뷰 요구사항(선택)

- 첫번째랑 두번재 문제는 배포 환경에서 발생하는 이슈라서 배포하고 다시 확인이 필요할것 같습니다.
- `PickerResponseData` 중 `nullable` 값을 수정할지 고민인데 다른 분들 생각이 궁금합니다.  
제가 고민하는 이유는 따로 `null`을 지정하지 않아도 `''` 이런식으로 데이터를 넘겨주기 때문입니다!
<img width="276" alt="image" src="https://github.com/KakaoFunding/front-end/assets/123801385/3136b1ff-e2c7-42c3-b4f4-52bd7839777a">
<img width="753" alt="image" src="https://github.com/KakaoFunding/front-end/assets/123801385/e3bf7cc0-bd08-422a-bb31-85fa835cba2d">


