### PR TITLE
Feat/304

### DIFF
--- a/src/hooks/usePaymentWindow.ts
+++ b/src/hooks/usePaymentWindow.ts
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export const usePaymentWindow = () => {
+  const navigate = useNavigate();
+  const [pgToken, setPgToken] = useState<string>('');
+
+  // 결제 모듈 팝업창 열기
+  const openPaymentWindow = (
+    redirectUrl: string,
+    width = 520,
+    height = 700,
+  ) => {
+    const left = window.outerWidth / 2 - width / 2;
+    const top = window.outerHeight / 2 - height / 2;
+    const features = [
+      `width=${width}`,
+      `height=${height}`,
+      `left=${left}`,
+      `top=${top}`,
+    ];
+
+    const paymentWindow = window.open(
+      redirectUrl,
+      '_blank',
+      features.join(','),
+    );
+    return paymentWindow;
+  };
+
+  // 결제 모듈 팝업창의 결제 상태(성공/실패/취소) 체크
+  const checkPaymentStatus = (
+    paymentWindow: Window,
+    onWindowClosed: () => void,
+    paymentType: 'gift' | 'funding',
+    state: object,
+  ) => {
+    // polling 방식으로 결제창 url 체크
+    const checkPaymentUrl = setInterval(() => {
+      if (paymentWindow.closed) {
+        onWindowClosed();
+        clearInterval(checkPaymentUrl);
+        return;
+      }
+
+      const paymentUrl = paymentWindow.location.href;
+
+      if (paymentUrl.includes('/payments')) {
+        paymentWindow.close();
+
+        if (paymentUrl.includes('/success')) {
+          const url = new URL(paymentUrl);
+          const urlParams = new URLSearchParams(url.search);
+          setPgToken(urlParams.get('pg_token')!);
+        } else if (paymentUrl.includes('/fail')) {
+          navigate('/payment/fail');
+        } else if (paymentUrl.includes('/cancel')) {
+          navigate('/payment/cancel', {
+            state: { paymentType, ...state },
+          });
+        }
+      }
+    }, 1000);
+  };
+
+  return { pgToken, openPaymentWindow, checkPaymentStatus };
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #304

## 📝작업 내용

- 선물/펀딩 결제 시 카카오페이 결제 모듈 창을 팝업함
- 결제 모듈 팝업 훅 생성

## 🙏리뷰 요구사항(선택)

- 펀딩 결제는 펀딩 등록이 아직 연동이 안 되어서 테스트를 못해봤습니다.
- 결제 버튼을 누르면 콘솔에 1초 간격으로 "CORS로 인해 location에 접근할 수 없다"는 식의 에러 메시지가 뜨는데요. 결제가 완료되기 전에는 결제 팝업창의 url origin(ex. `onlinepay-kakao.com`)과 저희 origin이 달라서 그렇습니다. 결제가 완료되고 나면 팝업창이 알아서 리다이렉트되는데 이 때는 url origin이 저희 origin과 같아지기 때문에(ex. `localhost:5173`) 더이상 에러 메시지가 뜨지 않습니다. 결제 팝업창의 url을 알기 위해 어쩔 수 없이 일어나는 자연스러운 현상인데, 혹시나 결제가 에러난다고 생각하실까봐 말씀드립니다.
