### PR TITLE
[fix]: 데이터가 페칭된 후 주문내역을 렌더링 하도록 변경(#331)

### DIFF
--- a/src/pages/MyPage/OrderHistory/index.tsx
+++ b/src/pages/MyPage/OrderHistory/index.tsx
@@ -19,7 +19,6 @@ import styles from './index.module.scss';
 
 const OrderHistory = () => {
   const [orderItems, setProducts] = useState<OrderItemType[]>([]);
-
   const [hasNext, setHasNext] = useState<boolean>(true);
   const [page, setPage] = useState<number>(0);
 
@@ -27,7 +26,7 @@ const OrderHistory = () => {
 
   const { startDate, endDate } = useDateFilter();
 
-  const { data, isLoading, refetch } = useQuery({
+  const { data, isLoading, refetch, isFetched } = useQuery({
     queryKey: ['orderHistory', startDate, endDate],
     queryFn: () => getOrderHistory(startDate, endDate),
   });
@@ -51,21 +50,25 @@ const OrderHistory = () => {
 
   return (
     <>
-      <div className={styles.title}>{`${name}님의 \n주문내역`}</div>
-      <FilterBar />
-      <div className={styles.wrapper_item}>
-        {hasOrderItem ? (
-          <ul>
-            {orderItems.map((item) => (
-              <li key={item.id}>
-                <OrderItem item={item} />
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <EmptyItem type="history_order" />
-        )}
-      </div>
+      {isFetched && (
+        <>
+          <div className={styles.title}>{`${name}님의 \n주문내역`}</div>
+          <FilterBar />
+          <div className={styles.wrapper_item}>
+            {hasOrderItem ? (
+              <ul>
+                {orderItems.map((item) => (
+                  <li key={item.id}>
+                    <OrderItem item={item} />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyItem type="history_order" />
+            )}
+          </div>
+        </>
+      )}
       {isLoading && <Spinner />}
       {!isLoading && hasNext && <div ref={observingTarget} />}
     </>


### PR DESCRIPTION
## #️⃣연관된 이슈
close: #331

## 📝작업 내용
- 주문내역페이지에서 EmptyItem 컴포넌트가 보인 뒤 주문내역이 렌더링 되는 문제 해결

## 🙏리뷰 요구사항(선택)

