### PR TITLE
Feat/324

### DIFF
--- a/src/layouts/Home/Receiver/index.tsx
+++ b/src/layouts/Home/Receiver/index.tsx
@@ -8,6 +8,8 @@ import { useKakaoPicker } from 'hooks/useKakaoPicker';
 import { useLogin } from 'hooks/useLogin';
 import { getSessionStorageItem } from 'utils/sessionStorage';
 
+import DefaultImgUrl from 'assets/bg_profile_default.png';
+
 import FriendFunding from './FriendFunding';
 import FriendWish from './FriendWish';
 
@@ -32,7 +34,8 @@ const Receiver = () => {
     (state) => state.clearSelectedFriends,
   );
   const { isLoggedIn, login, confirmLogin } = useLogin();
-  const PROFILE_IMAGE = isLoggedIn && isSelfSelected ? profileUrl : getImgUrl();
+  const PROFILE_IMAGE =
+    isLoggedIn && isSelfSelected ? profileUrl : getImgUrl(DefaultImgUrl);
   const isKakaoConnected = window.Kakao?.isInitialized();
 
   const getTitle = () => {

--- a/src/layouts/Product/BuyInfo/ButtonBundles/index.module.scss
+++ b/src/layouts/Product/BuyInfo/ButtonBundles/index.module.scss
@@ -47,13 +47,18 @@
   .btn_gift {
     @include size(40%, 60px, 0 0 0 5px, 0);
 
-    .img_profile {
+    .wrapper_profile {
       @include size(32px, 32px, 0, 0);
 
       position: relative;
       margin-right: 6px;
-      background-image: url('assets/profile_noimg.png');
-      background-size: cover;
+
+      .img_profile {
+        @include masking;
+
+        width: 100%;
+        object-fit: cover;
+      }
     }
 
     .ico_profile {

--- a/src/layouts/Product/BuyInfo/ButtonBundles/index.tsx
+++ b/src/layouts/Product/BuyInfo/ButtonBundles/index.tsx
@@ -130,6 +130,12 @@ const ButtonBundles = ({
     });
   };
 
+  // 친구 프로필 이미지 클릭 핸들러
+  const handleClickProfile = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    openKakaoPicker();
+  };
+
   // 선물상자 담기 버튼 핸들러
   const handleClickCart = () => {
     // console.log('선물상자 담기');
@@ -188,7 +194,7 @@ const ButtonBundles = ({
           onClick={handleClickGiftForFriend}
           className={styles.btn_gift}
         >
-          <div className={styles.wrapper_profile}>
+          <div className={styles.wrapper_profile} onClick={handleClickProfile}>
             <img
               src={getImgUrl(DefaultProfileImage)}
               alt="선물할 친구 프로필 사진"

--- a/src/layouts/Product/BuyInfo/ButtonBundles/index.tsx
+++ b/src/layouts/Product/BuyInfo/ButtonBundles/index.tsx
@@ -14,6 +14,8 @@ import { formatNumberWithPlus } from 'utils/format';
 import { RequestOrderPreview } from 'types/payment';
 import { OptionDetail, ProductDescriptionResponse } from 'types/product';
 
+import DefaultProfileImage from 'assets/profile_noimg.png';
+
 import styles from './index.module.scss';
 
 const mockData = {
@@ -37,7 +39,7 @@ const ButtonBundles = ({
     productDescription;
   const navigate = useNavigate();
   const { isLoggedIn, login, confirmLogin } = useLogin();
-  const { isSelected, isSelfSelected, selectedFriends } =
+  const { isSelected, isSelfSelected, selectedFriends, getImgUrl } =
     useSelectedFriendsStore();
   const { openKakaoPicker } = useKakaoPicker();
 
@@ -186,10 +188,14 @@ const ButtonBundles = ({
           onClick={handleClickGiftForFriend}
           className={styles.btn_gift}
         >
-          <span className={styles.img_profile}>
-            {/* TODO : 로그인 되었을 때만 보이게 */}
+          <div className={styles.wrapper_profile}>
+            <img
+              src={getImgUrl(DefaultProfileImage)}
+              alt="선물할 친구 프로필 사진"
+              className={styles.img_profile}
+            />
             <span className={styles.ico_profile} />
-          </span>
+          </div>
           선물하기
         </Button>
       </section>

--- a/src/layouts/Product/BuyInfo/ButtonBundles/index.tsx
+++ b/src/layouts/Product/BuyInfo/ButtonBundles/index.tsx
@@ -4,6 +4,9 @@ import { Button } from 'components/ui/Button';
 import FundingModal from 'components/ui/Modal/FundingModal';
 import WishModal from 'components/ui/Modal/WishModal';
 
+import { useSelectedFriendsStore } from 'store/useSelectedFriendsStore';
+
+import { useKakaoPicker } from 'hooks/useKakaoPicker';
 import { useLogin } from 'hooks/useLogin';
 import { useModal } from 'hooks/useModal';
 import { formatNumberWithPlus } from 'utils/format';
@@ -34,6 +37,9 @@ const ButtonBundles = ({
     productDescription;
   const navigate = useNavigate();
   const { isLoggedIn, login, confirmLogin } = useLogin();
+  const { isSelected, isSelfSelected, selectedFriends } =
+    useSelectedFriendsStore();
+  const { openKakaoPicker } = useKakaoPicker();
 
   const {
     isOpen: isFundingOpen,
@@ -107,9 +113,18 @@ const ButtonBundles = ({
   // 친구에게 선물하기 버튼 핸들러
   const handleClickGiftForFriend = () => {
     checkLoginBeforeAction(() => {
-      // TODO: 친구를 선택하지 않은 경우 피커 오픈
-      // 친구를 선택한 경우 선물 결제 페이지로 이동
-      navigate('/bill/gift', { state: { orderInfos, giftFor: 'friends' } });
+      if (!isSelected) {
+        openKakaoPicker();
+        return;
+      }
+
+      if (isSelfSelected) {
+        navigate('/bill/gift', { state: { orderInfos, giftFor: 'me' } });
+      } else if (selectedFriends.length === 1) {
+        navigate('/bill/gift', { state: { orderInfos, giftFor: 'friends' } });
+      } else {
+        alert('지금은 한 번에 한 명에게만 선물할 수 있어요.');
+      }
     });
   };
 

--- a/src/store/useSelectedFriendsStore.ts
+++ b/src/store/useSelectedFriendsStore.ts
@@ -3,7 +3,6 @@ import { persist } from 'zustand/middleware';
 
 import { PickerResponseData, User } from 'types/user';
 
-import defaultImgUrl from 'assets/bg_profile_default.png';
 import friendsDefaultImgUrl from 'assets/profile_default.png';
 import peopleImgUrl from 'assets/profile_people.png';
 
@@ -20,7 +19,7 @@ type SelectedFriendsAction = {
     name: User['name'],
     providerId: User['providerId'],
   ) => void;
-  getImgUrl: () => string;
+  getImgUrl: (defaultImgUrl: string) => string;
   clearSelectedFriends: () => void;
 };
 
@@ -54,7 +53,7 @@ export const useSelectedFriendsStore = create<
           selectedHeadCount: 0,
         }),
 
-      getImgUrl: () => {
+      getImgUrl: (defaultImgUrl: string) => {
         const selectCount = get().selectedHeadCount;
 
         if (selectCount > 1) return peopleImgUrl;


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #324

## 📝작업 내용

- 상품 상세 조회 페이지 - 친구에게 선물하기 버튼 핸들러 구현
- 버튼의 프로필사진 클릭 시 피커 열기
- 선택한 친구에 따라 버튼의 프로필 사진 변경되게 수정

## 🙏리뷰 요구사항

- 아직 여러 명을 대상으로 결제를 할 수가 없고, 한 명한테만 가능합니다. 그래서 여러 명이 선택되어 있을 때 선물하기 버튼을 누르면 경고 메시지를 띄우도록 구현했습니다. 참고 바랍니다.