### PR TITLE
Feat/312 소셜 로그아웃 요청 로직 추가

### DIFF
--- a/src/layouts/App/Header/LogoutModal/index.tsx
+++ b/src/layouts/App/Header/LogoutModal/index.tsx
@@ -28,13 +28,12 @@ const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
   const clearSelectedFiends = useSelectedFriendsStore(
     (state) => state.clearSelectedFriends,
   );
-  const accessToken = getSessionStorageItem('accessToken');
   const refreshToken = getLocalStorageItem('refreshToken');
   const socialAccessToken = getSessionStorageItem('socialToken');
   const { providerId } = useUserStore();
 
   const handleLogout = async () => {
-    await logout({ accessToken, refreshToken });
+    await logout({ refreshToken });
     await socialLogout({ providerId, socialAccessToken });
 
     clearUser();

--- a/src/layouts/App/Header/LogoutModal/index.tsx
+++ b/src/layouts/App/Header/LogoutModal/index.tsx
@@ -8,7 +8,7 @@ import {
   clearLocalStorageItem,
   getLocalStorageItem,
 } from 'services/api/v1/localStorage';
-import { logout } from 'services/api/v1/oauth';
+import { logout, socialLogout } from 'services/api/v1/oauth';
 import {
   clearSessionStorageItem,
   getSessionStorageItem,
@@ -30,9 +30,12 @@ const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
   );
   const accessToken = getSessionStorageItem('accessToken');
   const refreshToken = getLocalStorageItem('refreshToken');
+  const socialAccessToken = getSessionStorageItem('socialToken');
+  const { providerId } = useUserStore();
 
   const handleLogout = async () => {
     await logout({ accessToken, refreshToken });
+    await socialLogout({ providerId, socialAccessToken });
 
     clearUser();
     clearSelectedFiends();

--- a/src/services/api/v1/oauth.ts
+++ b/src/services/api/v1/oauth.ts
@@ -28,6 +28,16 @@ type LogoutRequestProps = {
   refreshToken: string | null;
 };
 
+type SocialLogoutRequestProps = {
+  socialAccessToken: string;
+  providerId: string;
+};
+
+type SocialLogoutResponseProps = {
+  message: string;
+  code: number;
+};
+
 // 로그인: 토큰 발급
 export const getKakaoOauthToken = async ({ code }: TokenRequestProps) => {
   const API_KEY = import.meta.env.VITE_REST_API_KEY;
@@ -82,5 +92,21 @@ export const logout = async ({
     { refreshToken },
     { headers },
   );
+  return response;
+};
+
+// 소셜 로그아웃
+export const socialLogout = async ({
+  providerId,
+  socialAccessToken,
+}: SocialLogoutRequestProps): Promise<
+  AxiosResponse<SocialLogoutResponseProps>
+> => {
+  const response = await apiV1.post('/oauth/social/logout', {
+    provider: 'KAKAO',
+    providerId,
+    socialAccessToken,
+  });
+
   return response;
 };

--- a/src/services/api/v1/oauth.ts
+++ b/src/services/api/v1/oauth.ts
@@ -24,8 +24,7 @@ type LoginResponseProps = {
 };
 
 type LogoutRequestProps = {
-  accessToken: string | null;
-  refreshToken: string | null;
+  refreshToken: string;
 };
 
 type SocialLogoutRequestProps = {
@@ -81,17 +80,9 @@ export const login = async ({
 
 // 로그아웃 요청
 export const logout = async ({
-  accessToken,
   refreshToken,
-}: LogoutRequestProps): Promise<AxiosResponse<LogoutRequestProps>> => {
-  const headers = {
-    Authorization: `Bearer ${accessToken}`,
-  };
-  const response = await apiV1.post(
-    '/oauth/logout',
-    { refreshToken },
-    { headers },
-  );
+}: LogoutRequestProps): Promise<AxiosResponse> => {
+  const response = await apiV1.post('/oauth/logout', { refreshToken });
   return response;
 };
 

--- a/src/services/api/v1/oauth.ts
+++ b/src/services/api/v1/oauth.ts
@@ -32,11 +32,6 @@ type SocialLogoutRequestProps = {
   providerId: string;
 };
 
-type SocialLogoutResponseProps = {
-  message: string;
-  code: number;
-};
-
 // 로그인: 토큰 발급
 export const getKakaoOauthToken = async ({ code }: TokenRequestProps) => {
   const API_KEY = import.meta.env.VITE_REST_API_KEY;
@@ -90,9 +85,7 @@ export const logout = async ({
 export const socialLogout = async ({
   providerId,
   socialAccessToken,
-}: SocialLogoutRequestProps): Promise<
-  AxiosResponse<SocialLogoutResponseProps>
-> => {
+}: SocialLogoutRequestProps): Promise<AxiosResponse> => {
   const response = await apiV1.post('/oauth/social/logout', {
     provider: 'KAKAO',
     providerId,


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #312 

## 📝작업 내용

- 로그아웃할 때 소셜 토큰을 만료시키기 위해 소셜 로그아웃 요청을 추가
- 로그아웃, 소셜 로그아웃 모두 리스폰스가 데이터가 없기 때문에 리스폰스 prop을 제거.
- 로그아웃 요청에 엑세스토큰 제거 -> 리퀘스트 인터셉터에서 자동으로 담아서 보내줌.
