### PR TITLE
Feat/341

### DIFF
--- a/src/layouts/App/Header/LogoutModal/index.tsx
+++ b/src/layouts/App/Header/LogoutModal/index.tsx
@@ -40,6 +40,7 @@ const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
     clearSelectedFiends();
     clearSessionStorageItem();
     clearLocalStorageItem('refreshToken');
+    clearLocalStorageItem('socialRefreshToken');
 
     navigate('/');
   };

--- a/src/services/api/v1/members.ts
+++ b/src/services/api/v1/members.ts
@@ -11,9 +11,30 @@ type RefreshAccessTokenResponseProps = {
   };
 };
 
+type RefreshSocialAccessTokenResponseProps = {
+  accessToken: string;
+  refreshToken: {
+    value: string | null;
+    expiration: number | null;
+  };
+};
+
 export const refreshAccessToken = async (
   refreshToken: string,
 ): Promise<AxiosResponse<RefreshAccessTokenResponseProps>> => {
   const response = await apiV1.post('/oauth/reissue', { refreshToken });
+  return response;
+};
+
+export const refreshSocialAccessToken = async (
+  socialAccessToken: string,
+  socialRefreshToken: string,
+): Promise<AxiosResponse<RefreshSocialAccessTokenResponseProps>> => {
+  const headers = { Authorization: `Bearer ${socialAccessToken}` };
+  const response = await apiV1.post(
+    '/oauth/social/reissue',
+    { provider: 'kakao', refreshToken: socialRefreshToken },
+    { headers },
+  );
   return response;
 };

--- a/src/services/api/v1/oauth.ts
+++ b/src/services/api/v1/oauth.ts
@@ -4,6 +4,8 @@ import { setSessionStorageItem } from 'utils/sessionStorage';
 
 import { User } from 'types/user';
 
+import { setLocalStorageItem } from './localStorage';
+
 import { apiV1 } from '.';
 
 type TokenRequestProps = {
@@ -55,7 +57,14 @@ export const getKakaoOauthToken = async ({ code }: TokenRequestProps) => {
     });
 
     const socialToken = res.data.access_token;
+    const socialRefreshToken = res.data.refresh_token;
+    const socialRefreshTokenExpiresIn = res.data.refresh_token_expires_in;
     setSessionStorageItem('socialToken', socialToken);
+    setLocalStorageItem(
+      'socialRefreshToken',
+      socialRefreshToken,
+      socialRefreshTokenExpiresIn,
+    );
     return socialToken;
   } catch (error) {
     console.warn(error);


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #341 

## 📝작업 내용

- 소셜 토큰 만료에 대한 재발급 요청 구현
- 카카오 리프레시 토큰을 로컬에 저장. -> 로그아웃 하면 제거.

## 🙏리뷰 요구사항(선택)

- 소셜 토큰이 사용되는 곳이 결제쪽만 확인이 되어서 결제 로직을 기반으로 구현했습니다. 혹시 제가 놓친곳이 있다면 알려주시면 수정하겠습니다.
- 소셜 토큰 재발급 요청 리스폰스 리프레시 토큰 값에 `null`이 포함되어 있는데 이는 카카오에서 리프레시 토큰 만료 1주일 전에만 값을 제대로 보내주고 외에는 `null`로 보내주기 때문에 포함되었습니다.
- 소셜 토큰에 경우 저희가 임의로 만료 시간을 지정할 수 없어서 테스트는 못해본 상황입니다.