### PR TITLE
[fix]: 친구 위시리스트 조회 API 메소드 변경 (#365)

### DIFF
--- a/src/layouts/Home/Receiver/FriendWish/index.tsx
+++ b/src/layouts/Home/Receiver/FriendWish/index.tsx
@@ -18,7 +18,7 @@ type FriendWishProps = {
 
 const FriendWish = ({ friendId, socialAccessToken }: FriendWishProps) => {
   const { data: wishlist, sendRequest } = useAxios<FriendWishItemType[]>({
-    method: 'get',
+    method: 'post',
     url: '/wishes/friends',
     data: {
       friendsProviderId: friendId,


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #365

## 📝작업 내용

- 친구의 위시리스트 조회 API 메소드를 GET에서 POST로 변경

## 🙏리뷰 요구사항

- 지난 PR에서 친구의 위시리스트 조회 API를 연동했는데, 400 Bad Request 에러가 발생했습니다. BE 담당 예찬님과 이야기한 결과 GET 요청인데 바디가 있어서 오류가 나는 것으로 추정했고, 이에 따라 메소드를 POST로 변경하기로 결정했씁니다!