### PR TITLE
[feat]: 장바구니 상품 삭제 api 연동(#357)

### DIFF
--- a/src/layouts/Cart/CartBoxItem/index.tsx
+++ b/src/layouts/Cart/CartBoxItem/index.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 
+import { useAxios } from 'hooks/useAxios';
 import { formatNumberWithComma, formatNumberWithUnit } from 'utils/format';
 
 import { CartItem } from 'types/cart';
@@ -7,12 +8,28 @@ import { CartItem } from 'types/cart';
 import styles from './index.module.scss';
 
 type CartBoxItemProps = {
+  refetch: () => void;
   item: CartItem;
   handleSelect: (productId: number) => void;
   isSelected: boolean;
 };
 
-const CartBoxItem = ({ item, handleSelect, isSelected }: CartBoxItemProps) => {
+const CartBoxItem = ({
+  refetch,
+  item,
+  handleSelect,
+  isSelected,
+}: CartBoxItemProps) => {
+  const { sendRequest } = useAxios({
+    method: 'delete',
+    url: `cart/${item.productId}`,
+  });
+
+  const handleDelete = async () => {
+    await sendRequest();
+    refetch();
+  };
+
   return (
     <div className={styles.wrapper_item}>
       <div
@@ -24,8 +41,7 @@ const CartBoxItem = ({ item, handleSelect, isSelected }: CartBoxItemProps) => {
           id="checkbox"
           className={clsx(styles.ico_input, { [styles.on]: isSelected })}
         />
-
-        <span className={styles.ico_delete} />
+        <span className={styles.ico_delete} onClick={handleDelete} />
       </div>
       <div className={styles.wrapper_prod}>
         <img

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -25,6 +25,7 @@ const Cart = () => {
     data: cartItems,
     isFetched,
     isLoading,
+    refetch,
   } = useQuery({
     queryKey: ['cart'],
     queryFn: () => getCartItems(),
@@ -81,6 +82,7 @@ const Cart = () => {
                       {cartItems!.map((item) => (
                         <li key={item.cartId}>
                           <CartBoxItem
+                            refetch={refetch}
                             item={item}
                             handleSelect={handleSelect}
                             isSelected={selectedItems.some(


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #357

## 📝작업 내용
- 장바구니 상품 삭제  API 연동

## 🙏리뷰 요구사항(선택)
- 356에서 갈라진 브랜치라서 356이 병합되면 dev로 병합하겠습니다.
- 삭제 요청이 정상적으로 작동은 되지만 UX가 상당히 이상해요 ㅠ 왜냐면 선택된 상품데이터는 장바구니 상품 정보랑 별개로 프론트에서 관리되고 있기 때문에 상품이 삭제됐을때 선택된 상품데이터 체크 로직이 수행되면서 조금 부자연스럽게 동작해요. api가 변경되면 고쳐질 것같습니다. 