### PR TITLE
[fix]: 펀딩 완료시 안내되는 버튼의 텍스트를 올바르게 수정(#374)

### DIFF
--- a/src/pages/FundingComplete/index.tsx
+++ b/src/pages/FundingComplete/index.tsx
@@ -55,7 +55,7 @@ const FundingComplete = () => {
             className={styles.btn}
             onClick={handleClickFundingHistory}
           >
-            펀딩내역
+            펀딩 아이템 보러가기
           </Button>
           <Button
             color="yellow"

--- a/src/pages/FundingComplete/index.tsx
+++ b/src/pages/FundingComplete/index.tsx
@@ -55,14 +55,14 @@ const FundingComplete = () => {
             className={styles.btn}
             onClick={handleClickFundingHistory}
           >
-            펀딩 아이템 보러가기
+            펀딩내역 보기
           </Button>
           <Button
             color="yellow"
             className={styles.btn}
             onClick={handleClickMyFunding}
           >
-            펀딩함 가기
+            펀딩 아이템 보기
           </Button>
         </div>
       </section>

--- a/src/pages/GiftComplete/index.tsx
+++ b/src/pages/GiftComplete/index.tsx
@@ -70,7 +70,7 @@ const GiftComplete = () => {
             className={styles.btn}
             onClick={handleClickOrderHistory}
           >
-            주문내역
+            주문내역 보기
           </Button>
           <Button
             color="yellow"


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #374

## 📝작업 내용

- 펀딩 완료시 안내되는 버튼의 텍스트를 올바르게 수정



## 🙏리뷰 요구사항(선택)
- 제가 정신놓고해서 처음에 텍스트를 잘못입력했네요... 최종적으로 `펀딩내역보기`. `펀딩 아이템 보기`로 작성했는데 더 좋은 의견이 있다면 코멘트 부탁드립니다.