### PR TITLE
리프레시 토큰 쿠키로 변경

### DIFF
--- a/src/layouts/App/Header/LogoutModal/index.tsx
+++ b/src/layouts/App/Header/LogoutModal/index.tsx
@@ -4,10 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSelectedFriendsStore } from 'store/useSelectedFriendsStore';
 import { useUserStore } from 'store/useUserStore';
 
-import {
-  clearLocalStorageItem,
-  getLocalStorageItem,
-} from 'services/api/v1/localStorage';
+import { clearLocalStorageItem } from 'services/api/v1/localStorage';
 import { logout, socialLogout } from 'services/api/v1/oauth';
 import {
   clearSessionStorageItem,
@@ -28,18 +25,16 @@ const LogoutModal = ({ modalState, userState }: LogoutModalProps) => {
   const clearSelectedFiends = useSelectedFriendsStore(
     (state) => state.clearSelectedFriends,
   );
-  const refreshToken = getLocalStorageItem('refreshToken');
   const socialAccessToken = getSessionStorageItem('socialToken');
   const { providerId } = useUserStore();
 
   const handleLogout = async () => {
-    await logout({ refreshToken });
+    await logout();
     await socialLogout({ providerId, socialAccessToken });
 
     clearUser();
     clearSelectedFiends();
     clearSessionStorageItem();
-    clearLocalStorageItem('refreshToken');
     clearLocalStorageItem('socialRefreshToken');
 
     navigate('/');

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -5,7 +5,6 @@ import Spinner from 'components/ui/Spinner';
 
 import { useUserStore } from 'store/useUserStore';
 
-import { setLocalStorageItem } from 'services/api/v1/localStorage';
 import { getKakaoOauthToken, login } from 'services/api/v1/oauth';
 import { setSessionStorageItem } from 'utils/sessionStorage';
 
@@ -28,10 +27,8 @@ const Auth = () => {
         const socialAccessToken = await getKakaoOauthToken({ code });
 
         const res = await login({ socialAccessToken });
-        const { accessToken, member, refreshToken } = res.data;
-        const { value, expiration } = refreshToken;
+        const { accessToken, member } = res.data;
 
-        setLocalStorageItem('refreshToken', value, expiration);
         setSessionStorageItem('accessToken', accessToken);
         setUserInfo(member);
         navigate(loginState);

--- a/src/services/api/v1/index.ts
+++ b/src/services/api/v1/index.ts
@@ -45,16 +45,13 @@ apiV1.interceptors.response.use(
 
     if (status === 401) {
       if (error.response.data.code === 'KF003') {
-        const usersRefreshToken = getLocalStorageItem('refreshToken');
         apiV1.defaults.headers.common.Authorization = null;
-        const response = await refreshAccessToken(usersRefreshToken);
+        const response = await refreshAccessToken();
 
         if (response.status === 200) {
-          const { accessToken, refreshToken } = response.data;
-          const { value, expiration } = refreshToken;
+          const { accessToken } = response.data;
 
           setSessionStorageItem('accessToken', accessToken);
-          setLocalStorageItem('refreshToken', value, expiration);
 
           axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
           originRequest.headers.Authorization = `Bearer ${accessToken}`;
@@ -68,13 +65,6 @@ apiV1.interceptors.response.use(
               originRequest.data = [...parsedOriginData];
             } else if (typeof parsedOriginData === 'object') {
               originRequest.data = { ...parsedOriginData };
-
-              if (parsedOriginData.refreshToken) {
-                originRequest.data = {
-                  ...parsedOriginData,
-                  refreshToken: value,
-                };
-              }
             }
           }
 

--- a/src/services/api/v1/members.ts
+++ b/src/services/api/v1/members.ts
@@ -5,10 +5,6 @@ import { apiV1 } from '.';
 
 type RefreshAccessTokenResponseProps = {
   accessToken: string;
-  refreshToken: {
-    value: string;
-    expiration: number;
-  };
 };
 
 type RefreshSocialAccessTokenResponseProps = {
@@ -19,10 +15,16 @@ type RefreshSocialAccessTokenResponseProps = {
   };
 };
 
-export const refreshAccessToken = async (
-  refreshToken: string,
-): Promise<AxiosResponse<RefreshAccessTokenResponseProps>> => {
-  const response = await apiV1.post('/oauth/reissue', { refreshToken });
+export const refreshAccessToken = async (): Promise<
+  AxiosResponse<RefreshAccessTokenResponseProps>
+> => {
+  const response = await apiV1.post(
+    '/oauth/reissue',
+    {},
+    {
+      withCredentials: true,
+    },
+  );
   return response;
 };
 

--- a/src/services/api/v1/oauth.ts
+++ b/src/services/api/v1/oauth.ts
@@ -19,10 +19,6 @@ type LoginRequestProps = {
 type LoginResponseProps = {
   accessToken: string;
   member: NonNullable<User>;
-  refreshToken: {
-    value: string;
-    expiration: number;
-  };
 };
 
 type LogoutRequestProps = {

--- a/src/services/api/v1/oauth.ts
+++ b/src/services/api/v1/oauth.ts
@@ -21,10 +21,6 @@ type LoginResponseProps = {
   member: NonNullable<User>;
 };
 
-type LogoutRequestProps = {
-  refreshToken: string;
-};
-
 type SocialLogoutRequestProps = {
   socialAccessToken: string;
   providerId: string;
@@ -85,10 +81,12 @@ export const login = async ({
 };
 
 // 로그아웃 요청
-export const logout = async ({
-  refreshToken,
-}: LogoutRequestProps): Promise<AxiosResponse> => {
-  const response = await apiV1.post('/oauth/logout', { refreshToken });
+export const logout = async (): Promise<AxiosResponse> => {
+  const response = await apiV1.post(
+    '/oauth/logout',
+    {},
+    { withCredentials: true },
+  );
   return response;
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close: #389 

## 📝작업 내용

- 로그인할 때 스토리지에 저장하던 리프레시 토큰을 쿠키로 변경.
- 로그아웃, 재발급 요청 바디에서 리프레시 토큰을 제거하고 요청 헤더에 포함.

## 🙏리뷰 요구사항(선택)

현재 서버가 너무 느려서 많은 테스트를 진행하지는 못했습니다. 
우선 로그아웃할 때 재발급이 잘되는것은 확인했습니다.
